### PR TITLE
Adds option to ungroup same name mobs in the mob list

### DIFF
--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/MobList.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/MobList.cs
@@ -110,6 +110,16 @@ namespace ACT.UltraScouter.Config
             get => this.visibleMe;
             set => this.SetProperty(ref this.visibleMe, value);
         }
+ 
+        /// <summary>
+        /// 同名のモブを個別表示するか？
+        /// </summary>
+        [DataMember]
+        public bool UngroupSameNameMobs
+        {
+            get => this.ungroupSameNameMobs;
+            set => this.SetProperty(ref this.ungroupSameNameMobs, value);
+        }
 
         /// <summary>
         /// 方向の基準

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/Views/MobListConfigView.xaml
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/Views/MobListConfigView.xaml
@@ -55,6 +55,11 @@
         Margin="0 5 0 0"
         Content="{DynamicResource MobList_VisibleMePosition}"
         IsChecked="{Binding MobList.VisibleMe, Mode=TwoWay}" />
+      
+      <CheckBox
+        Margin="0 5 0 0"
+        Content="{DynamicResource MobList_UngroupSameNameMobs}"
+        IsChecked="{Binding MobList.UngroupSameNameMobs, Mode=TwoWay}" />
 
       <CheckBox
         Margin="0 5 0 0"

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MobListWorker.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MobListWorker.cs
@@ -320,7 +320,7 @@ namespace ACT.UltraScouter.Workers
                 if (Settings.Instance.MobList.UngroupSameNameMobs)
                 {
                     moblist = (
-                        from x in this.targetMobList.OrderBy(y => y.Distance)).ToList();     
+                        this.targetMobList.OrderBy(y => y.Distance)).ToList();     
                 }
                 else
                 {

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MobListWorker.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MobListWorker.cs
@@ -317,13 +317,21 @@ namespace ACT.UltraScouter.Workers
             var moblist = default(IReadOnlyList<MobInfo>);
             lock (this.TargetInfoLock)
             {
-                moblist = (
-                    from x in this.targetMobList.OrderBy(y => y.Distance)
-                    group x by x.Name into g
-                    select g.First().Clone((clone =>
-                    {
-                        clone.DuplicateCount = g.Count();
-                    }))).ToList();
+                if (Settings.Instance.MobList.UngroupSameNameMobs)
+                {
+                    moblist = (
+                        from x in this.targetMobList.OrderBy(y => y.Distance)).ToList();     
+                }
+                else
+                {
+                    moblist = (
+                        from x in this.targetMobList.OrderBy(y => y.Distance)
+                        group x by x.Name into g
+                        select g.First().Clone((clone =>
+                        {
+                            clone.DuplicateCount = g.Count();
+                        }))).ToList();
+                }
             }
 
             // 表示件数によるフィルタをかけるメソッド

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/resources/strings/Strings.UlSco.en-US.xaml
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/resources/strings/Strings.UlSco.en-US.xaml
@@ -80,6 +80,7 @@
 
   <system:String x:Key="MobList_VisibleMePosition">Visible Me position</system:String>
   <system:String x:Key="MobList_SimpleView">Simple View</system:String>
+  <system:String x:Key="MobList_UngroupSameNameMobs">Ungroup same name mobs</system:String>
   <system:String x:Key="MobList_VisibleZPosition">Visible Z position</system:String>
   <system:String x:Key="MobList_DirectionOrigin">Origin of Direction</system:String>
   <system:String x:Key="MobList_DirectionAdjustmentAngle">Direction adjustment angle</system:String>

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/resources/strings/Strings.UlSco.ja-JP.xaml
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/resources/strings/Strings.UlSco.ja-JP.xaml
@@ -80,6 +80,7 @@
 
   <system:String x:Key="MobList_VisibleMePosition">自分の座標を表示する</system:String>
   <system:String x:Key="MobList_SimpleView">シンプル表示にする</system:String>
+  <system:String x:Key="MobList_UngroupSameNameMobs">同名のモブを個別表示</system:String>
   <system:String x:Key="MobList_VisibleZPosition">Z軸を表示する</system:String>
   <system:String x:Key="MobList_DirectionOrigin">方向表示の基準</system:String>
   <system:String x:Key="MobList_DirectionAdjustmentAngle">方向の補正角度</system:String>


### PR DESCRIPTION
When enabled, lists same name mobs individually instead of grouping them up and show counts.
Useful for contents like Heaven on High where you want to keep track of all wondering mobs.