### PR TITLE
スぺスぺたいむ - <zone> tag to recognize zone ID

### DIFF
--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineController.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineController.cs
@@ -203,6 +203,13 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                 }
 
                 if (string.Equals(
+                        FFXIVPlugin.Instance?.GetCurrentZoneID().ToString().Trim(),
+                        this.Model.Zone.Trim()))
+                {
+                    return true;
+                }
+
+                if (string.Equals(
                         ActGlobals.oFormActMain.CurrentZone.Trim(),
                         this.Model.Zone.Trim(),
                         StringComparison.OrdinalIgnoreCase))
@@ -218,7 +225,10 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                     string.Equals(
                         ActGlobals.oFormActMain.CurrentZone.Trim(),
                         x.Trim(),
-                        StringComparison.OrdinalIgnoreCase));
+                        StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(
+                        FFXIVPlugin.Instance?.GetCurrentZoneID().ToString().Trim(),
+                        x.Trim()));
             }
         }
 


### PR DESCRIPTION
### 必要性
韓国鯖のクライアントではZone名で零式かノーマルかを区別し難い場合があります。

![issue](https://user-images.githubusercontent.com/2058393/56865001-f33fc680-6a03-11e9-904e-c7a05eecd22b.PNG)
このように零式とノーマルのZone名が同じ、さらにアルファ編の３層と4層はZone名までも同じです。

### 変更点
```
ACT.SpecialSpellTimer.Core
→ RaidTimeline
  → TimelineController.cs
    → TimelineControllerクラス
      → IsAvailableメソッドを修正
```
```c#
if (string.Equals(
        FFXIVPlugin.Instance?.GetCurrentZoneID().ToString().Trim(),
        this.Model.Zone.Trim()))
{
    return true;
}

…

return zones.Any(x =>
    string.Equals(
        ActGlobals.oFormActMain.CurrentZone.Trim(),
        x.Trim(),
        StringComparison.OrdinalIgnoreCase) ||
    string.Equals(
        FFXIVPlugin.Instance?.GetCurrentZoneID().ToString().Trim(),
        x.Trim()));
```
-------------
私のテストでは問題なさそうでした。
必要な機能だと思われますのでご検討よろしくお願いします。
ありがとうございます。