### PR TITLE
Changed to get InCombat from Sharlayan instead of FFXIVPlugin

### DIFF
--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/Views/FFLogsConfigView.xaml
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/Views/FFLogsConfigView.xaml
@@ -55,8 +55,7 @@
       <CheckBox
         Margin="0 5 0 0"
         Content="{DynamicResource FFLogs_HideInCombat}"
-        IsChecked="{Binding FFLogs.HideInCombat, Mode=TwoWay}"
-        ToolTip="{DynamicResource FFLogs_HideInCombatDescription}" />
+        IsChecked="{Binding FFLogs.HideInCombat, Mode=TwoWay}" />
       <CheckBox
         Margin="0 5 0 0"
         Content="{DynamicResource Common_TestMode}"

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/TargetInfoModel.Enmity.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/TargetInfoModel.Enmity.cs
@@ -223,7 +223,7 @@ namespace ACT.UltraScouter.Models
                 else
                 {
                     if (config.HideInNotCombat &&
-                        !FFXIVPlugin.Instance.InCombat)
+                        !SharlayanHelper.Instance.CurrentPlayer.InCombat)
                     {
                         this.enmityList.Clear();
                         this.IsExistsEnmityList = false;

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/EnmityViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/EnmityViewModel.cs
@@ -54,7 +54,7 @@ namespace ACT.UltraScouter.ViewModels
                 }
 
                 if (this.Config.HideInNotCombat &&
-                    !FFXIVPlugin.Instance.InCombat)
+                    !SharlayanHelper.Instance.CurrentPlayer.InCombat)
                 {
                     return false;
                 }

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/FFLogsViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/FFLogsViewModel.cs
@@ -58,7 +58,7 @@ namespace ACT.UltraScouter.ViewModels
                 }
 
                 if (this.Config.HideInCombat &&
-                    FFXIVPlugin.Instance.InCombat)
+                    SharlayanHelper.Instance.CurrentPlayer.InCombat)
                 {
                     return false;
                 }


### PR DESCRIPTION
### 必要性
#### FFXIVPluginは戦闘中を判定する基準が不正確
```Current HP/MP/TP != Max HP/MP/TP```の時、戦闘中だと判断する動作によって誤認する場合があります。
>ex.
>ジョブチェンジなど最大HP・MPが変わる時
>戦闘前にプロテス・鼓舞などを使う時

#### SharlayanはメモリーのCombatFlagsから取得
上記のような問題が発生しない。

[Sharlayan/Core/ActorItem.cs](https://github.com/FFXIVAPP/sharlayan/blob/2ae237b805f25e4943c4c601376f8109766de06d/Sharlayan/Core/ActorItem.cs#L66)
[Sharlayan/Utilities/ActorItemResolver.cs](https://github.com/FFXIVAPP/sharlayan/blob/2ae237b805f25e4943c4c601376f8109766de06d/Sharlayan/Utilities/ActorItemResolver.cs#L98)


### 変更点
```FFXIVPlugin.Instance.InCombat``` → ```SharlayanHelper.Instance.CurrentPlayer.InCombat```

----

ご検討よろしくお願いします。
ありがとうございます。