### PR TITLE
Google Cloud Text-to-Speechに対応した

### DIFF
--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/ACT.TTSYukkuri.Core.csproj
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/ACT.TTSYukkuri.Core.csproj
@@ -93,6 +93,7 @@
   <ItemGroup>
     <Compile Include="Boyomichan\BoyomichanSpeechController.cs" />
     <Compile Include="Config\DiscordSettings.cs" />
+    <Compile Include="Config\GoogleCloudTextToSpeechConfig.cs" />
     <Compile Include="Config\HOYAConfig.cs" />
     <Compile Include="Config\JobsExtension.cs" />
     <Compile Include="Config\OpenJTalkConfig.cs" />
@@ -104,6 +105,7 @@
     <Compile Include="Config\Settings.cs" />
     <Compile Include="Config\ViewModels\GeneralViewModel.cs" />
     <Compile Include="Config\ViewModels\BoyomiConfigViewModel.cs" />
+    <Compile Include="Config\ViewModels\GoogleCloudTextToSpeechViewModel.cs" />
     <Compile Include="Config\ViewModels\PollyConfigViewModel.cs" />
     <Compile Include="Config\ViewModels\SAPI5ConfigViewModel.cs" />
     <Compile Include="Config\ViewModels\VoiceroidConfigViewModel.cs" />
@@ -120,6 +122,9 @@
     </Compile>
     <Compile Include="Config\Views\GeneralView.xaml.cs">
       <DependentUpon>GeneralView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Config\Views\GoogleCloudTextToSpeechConfigView.xaml.cs">
+      <DependentUpon>GoogleCloudTextToSpeechConfigView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Config\Views\HoyaConfigView.xaml.cs">
       <DependentUpon>HoyaConfigView.xaml</DependentUpon>
@@ -162,6 +167,7 @@
     </Compile>
     <Compile Include="FFXIVWatcher.cs" />
     <Compile Include="FFXIVWatcher.PartyWatcher.cs" />
+    <Compile Include="GoogleCloudTextToSpeech\GoogleCloudTextToSpeechSpeechController.cs" />
     <Compile Include="HOYA\HOYASpeechController.cs" />
     <Compile Include="HOYA\VoiceTextWebAPI.Client\Emotion.cs" />
     <Compile Include="HOYA\VoiceTextWebAPI.Client\EmotionLevel.cs" />
@@ -336,6 +342,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Config\Views\GoogleCloudTextToSpeechConfigView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Config\Views\HoyaConfigView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -418,6 +428,9 @@
     </PackageReference>
     <PackageReference Include="FontAwesome.WPF">
       <Version>4.7.0.9</Version>
+    </PackageReference>
+    <PackageReference Include="Google.Cloud.TextToSpeech.V1">
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="MahApps.Metro.IconPacks">
       <Version>2.3.0</Version>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/GoogleCloudTextToSpeechConfig.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/GoogleCloudTextToSpeechConfig.cs
@@ -1,0 +1,181 @@
+﻿using Google.Cloud.TextToSpeech.V1;
+using Prism.Mvvm;
+using System;
+using System.Globalization;
+using System.Linq;
+using ACT.TTSYukkuri.Config.ViewModels;
+
+namespace ACT.TTSYukkuri.Config
+{
+    [Serializable]
+    public class GoogleCloudTextToSpeechConfig :
+        BindableBase
+    {
+        private TextToSpeechClient client = TextToSpeechClient.Create();
+
+        private string languageCode;
+        private string name;
+        private double volumeGainDb;
+        private double pitch;
+        private double speakingRate;
+        private int sampleRateHertz;
+        private GoogleCloudTextToSpeechVoice[] voiceList;
+
+        public GoogleCloudTextToSpeechConfig()
+        {
+            this.SetRecommend();
+        }
+
+        /// <summary>
+        /// 言語 [BCP-47]
+        /// </summary>
+        public string LanguageCode
+        {
+            get => this.languageCode;
+            set
+            {
+                this.SetProperty(ref this.languageCode, value);
+                this.VoiceList = EnumerateVoice();
+            }
+        }
+
+        /// <summary>
+        /// 音声名
+        /// </summary>
+        public string Name
+        {
+            get => this.name;
+            set => this.SetProperty(ref this.name, value);
+        }
+
+        /// <summary>
+        /// ボリューム [db] -96.0 ～ 16.0
+        /// </summary>
+        public double VolumeGainDb
+        {
+            get => this.volumeGainDb;
+            set => this.SetProperty(ref this.volumeGainDb, value);
+        }
+
+        /// <summary>
+        /// ピッチ -20.0 ～ 20.0
+        /// </summary>
+        public double Pitch
+        {
+            get => this.pitch;
+            set => this.SetProperty(ref this.pitch, value);
+        }
+
+        /// <summary>
+        /// レート 0.25 ～ 4.0
+        /// </summary>
+        public double SpeakingRate
+        {
+            get => this.speakingRate;
+            set => this.SetProperty(ref this.speakingRate, value);
+        }
+
+        /// <summary>
+        /// サンプリング周波数
+        /// </summary>
+        public int SampleRateHertz
+        {
+            get => this.sampleRateHertz;
+            set => this.SetProperty(ref this.sampleRateHertz, value);
+        }
+
+        /// <summary>
+        /// 音声リスト
+        /// </summary>
+        public GoogleCloudTextToSpeechVoice[] VoiceList
+        {
+            get => this.voiceList;
+            set => this.SetProperty(ref this.voiceList, value);
+        }
+
+        /// <summary>
+        /// 推奨値を設定する
+        /// </summary>
+        public void SetRecommend()
+        {
+            this.LanguageCode = "ja-JP";
+            this.VolumeGainDb = 0.0;
+            this.Pitch = 0.0;
+            this.SpeakingRate = 1.0;
+            this.SampleRateHertz = 44100;
+            this.VoiceList = EnumerateVoice();
+            this.Name = "ja-JP-Wavenet-A";
+        }
+
+        public GoogleCloudTextToSpeechLanguageCode[] EnumerateLanguageCode()
+        {
+            // C# で国名の一覧を取得・表示する - ディーバ Blog https://blog.divakk.co.jp/entry/2017/01/23/123226
+            return CultureInfo
+                .GetCultures(CultureTypes.SpecificCultures)
+                .Where(c => c.LCID != 4096 /* LOCALE_CUSTOM_UNSPECIFIED を除く */)
+                .OrderBy(c => c.DisplayName)
+                .Select(c => new GoogleCloudTextToSpeechLanguageCode { Info = c })
+                .ToArray();
+        }
+
+        public GoogleCloudTextToSpeechVoice[] EnumerateVoice()
+        {
+            return client
+                .ListVoices(LanguageCode)
+                .Voices
+                .Select(x => new GoogleCloudTextToSpeechVoice { VoiceName = x.Name })
+                .ToArray();
+        }
+
+        public GoogleCloudTextToSpeechSampleRateHertz[] EnumerateSampleRateHertz()
+        {
+            return new int[] { 8000, 11025, 16000, 22050, 32000, 44100, 48000, 96000, 192000 }
+                .Select(x => new GoogleCloudTextToSpeechSampleRateHertz { SampleRateHertz = x })
+                .ToArray();
+        }
+
+        public override string ToString() =>
+            $"{nameof(this.LanguageCode)}:{this.LanguageCode}," +
+            $"{nameof(this.Name)}:{this.Name}," +
+            $"{nameof(this.VolumeGainDb)}:{this.VolumeGainDb}," +
+            $"{nameof(this.Pitch)}:{this.Pitch}," +
+            $"{nameof(this.SpeakingRate)}:{this.SpeakingRate}," +
+            $"{nameof(this.SampleRateHertz)}:{this.SampleRateHertz}";
+    }
+
+    [Serializable]
+    public class GoogleCloudTextToSpeechLanguageCode
+    {
+        public string Value => Info.Name;
+
+        public string Name => Info.DisplayName;
+
+        public CultureInfo Info { get; set; }
+
+        public override string ToString() => this.Name;
+    }
+
+    [Serializable]
+    public class GoogleCloudTextToSpeechVoice
+    {
+        public string Value => VoiceName;
+
+        public string Name => VoiceName;
+
+        public string VoiceName { get; set; }
+
+        public override string ToString() => this.Name;
+    }
+
+    [Serializable]
+    public class GoogleCloudTextToSpeechSampleRateHertz
+    {
+        public int Value => SampleRateHertz;
+
+        public string Name => SampleRateHertz.ToString();
+
+        public int SampleRateHertz { get; set; }
+
+        public override string ToString() => this.Name;
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Settings.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Settings.cs
@@ -87,6 +87,7 @@ namespace ACT.TTSYukkuri.Config
         private SasaraConfig sasaraSettings = new SasaraConfig();
         private VoiceroidConfig voiceroidSettings = new VoiceroidConfig();
         private SAPI5Configs sapi5Settings = new SAPI5Configs();
+        private GoogleCloudTextToSpeechConfig googleCloudTextToSpeechSettings = new GoogleCloudTextToSpeechConfig();
         private StatusAlertConfig statusAlertSettings = new StatusAlertConfig();
         private DiscordSettings discordSettings = new DiscordSettings();
 
@@ -372,6 +373,15 @@ namespace ACT.TTSYukkuri.Config
         {
             get => this.sapi5Settings;
             set => this.SetProperty(ref this.sapi5Settings, value);
+        }
+
+        /// <summary>
+        /// Google Cloud Text-To-Speechの設定
+        /// </summary>
+        public GoogleCloudTextToSpeechConfig GoogleCloudTextToSpeechSettings
+        {
+            get => this.googleCloudTextToSpeechSettings;
+            set => this.SetProperty(ref this.googleCloudTextToSpeechSettings, value);
         }
 
         /// <summary>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GoogleCloudTextToSpeechViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GoogleCloudTextToSpeechViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Prism.Commands;
+using System.Windows.Input;
+
+namespace ACT.TTSYukkuri.Config.ViewModels
+{
+    public class GoogleCloudTextToSpeechConfigViewModel
+    {
+        public GoogleCloudTextToSpeechConfig Config => Settings.Default.GoogleCloudTextToSpeechSettings;
+
+        public GoogleCloudTextToSpeechLanguageCode[] LanguageCodeList => Settings.Default.GoogleCloudTextToSpeechSettings.EnumerateLanguageCode();
+
+        public GoogleCloudTextToSpeechSampleRateHertz[] SampleRateHertzList => Settings.Default.GoogleCloudTextToSpeechSettings.EnumerateSampleRateHertz();
+
+        private ICommand setRecommendCommand;
+
+        public ICommand SetRecommendCommand =>
+            this.setRecommendCommand ?? (this.setRecommendCommand = new DelegateCommand(() =>
+            {
+                this.Config.SetRecommend();
+            }));
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml.cs
@@ -154,6 +154,10 @@ namespace ACT.TTSYukkuri.Config.Views
                 case TTSType.SAPI5:
                     content = new SAPI5ConfigView();
                     break;
+
+                case TTSType.GoogleCloudTextToSpeech:
+                    content = new GoogleCloudTextToSpeechConfigView();
+                    break;
             }
 
             this.ContentGrid.Children.Clear();

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigView.xaml
@@ -1,0 +1,264 @@
+﻿<UserControl
+  x:Class="ACT.TTSYukkuri.Config.Views.GoogleCloudTextToSpeechConfigView"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:wpf="clr-namespace:FFXIV.Framework.WPF;assembly=FFXIV.Framework"
+  xmlns:system="clr-namespace:System;assembly=mscorlib"
+  xmlns:vm="clr-namespace:ACT.TTSYukkuri.Config.ViewModels"
+  xmlns:resources="clr-namespace:ACT.TTSYukkuri.resources"
+  xmlns:yukkuri="clr-namespace:ACT.TTSYukkuri.Yukkuri"
+  xmlns:global="clr-namespace:FFXIV.Framework.Globalization;assembly=FFXIV.Framework"
+  xmlns:fwcmn="clr-namespace:FFXIV.Framework.Common;assembly=FFXIV.Framework"
+  xmlns:fwcnv="clr-namespace:FFXIV.Framework.WPF.Converters;assembly=FFXIV.Framework"
+  xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+  mc:Ignorable="d"
+  TextOptions.TextFormattingMode="Display"
+  TextOptions.TextHintingMode="Animated"
+  TextOptions.TextRenderingMode="ClearType"
+  RenderOptions.ClearTypeHint="Enabled"
+  RenderOptions.BitmapScalingMode="HighQuality"
+  RenderOptions.EdgeMode="Unspecified"
+  Background="White"
+  FontFamily="Consolas, Yu Gothic UI, Meiryo UI"
+  FontSize="17"
+  d:DesignWidth="600"
+  d:DataContext="{d:DesignInstance Type=vm:GoogleCloudTextToSpeechConfigViewModel, IsDesignTimeCreatable=True}"
+  DataContext="{Binding RelativeSource={RelativeSource Self}}">
+
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <FontFamily x:Key="FontAwesome">pack://application:,,,/FontAwesome.WPF;component/#FontAwesome</FontFamily>
+      <fwcnv:BoolToCollapsedConverter x:Key="VisibilityConverter" />
+      <fwcnv:BoolToHiddenConverter x:Key="HiddenConverter" />
+
+      <ResourceDictionary.MergedDictionaries>
+        <wpf:DesignTimeResourceDictionary Source="../../resources/strings/Strings.Yukkuri.ja-JP.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <ScrollViewer
+    HorizontalScrollBarVisibility="Disabled"
+    VerticalScrollBarVisibility="Auto">
+    <StackPanel Orientation="Vertical">
+      <Label Content="{DynamicResource GoogleCloudTextToSpeech_Language}" />
+      <ComboBox
+        HorizontalAlignment="Left"
+        MinWidth="350"
+        ItemsSource="{Binding LanguageCodeList, Mode=OneWay}"
+        DisplayMemberPath="Name"
+        SelectedValuePath="Value"
+        SelectedValue="{Binding Config.LanguageCode, Mode=TwoWay}">
+      </ComboBox>
+
+      <Label Content="{DynamicResource GoogleCloudTextToSpeech_Name}" />
+      <ComboBox
+        HorizontalAlignment="Left"
+        MinWidth="350"
+        ItemsSource="{Binding Config.VoiceList, Mode=TwoWay}"
+        DisplayMemberPath="Name"
+        SelectedValuePath="Value"
+        SelectedValue="{Binding Config.Name, Mode=TwoWay}">
+      </ComboBox>
+
+      <!-- Volume Gain Db -->
+      <Label
+        Margin="5 10 0 0"
+        MinWidth="100"
+        Padding="0"
+        Content="{DynamicResource GoogleCloudTextToSpeech_VolumeGainDb}" />
+      <StackPanel Orientation="Horizontal" Margin="0 0 0 0">
+        <Label
+          Margin="0 0 0 0"
+          MinWidth="60"
+          HorizontalContentAlignment="Right"
+          Content="{Binding ElementName=GainSlider, Path=Value, Mode=OneWay}"
+          ContentStringFormat="N2" />
+        <Slider
+          Margin="5 0 0 0"
+          x:Name="GainSlider"
+          HorizontalAlignment="Left"
+          VerticalAlignment="Center"
+          SmallChange="0.1"
+          LargeChange="0.1"
+          Minimum="-96.0" Maximum="16.0"
+          Width="250"
+          Value="{Binding Config.VolumeGainDb, Mode=TwoWay}" />
+      </StackPanel>
+
+      <!-- Pitch -->
+      <Label
+        Margin="5 10 0 0"
+        MinWidth="100"
+        Padding="0"
+        Content="{DynamicResource GoogleCloudTextToSpeech_Pitch}" />
+      <StackPanel Orientation="Horizontal" Margin="0 0 0 0">
+        <Label
+          Margin="0 0 0 0"
+          MinWidth="60"
+          HorizontalContentAlignment="Right"
+          Content="{Binding ElementName=VolumeSlider, Path=Value, Mode=OneWay}"
+          ContentStringFormat="N2" />
+        <Slider
+          Margin="5 0 0 0"
+          x:Name="VolumeSlider"
+          HorizontalAlignment="Left"
+          VerticalAlignment="Center"
+          SmallChange="0.1"
+          LargeChange="0.1"
+          Minimum="-20.0" Maximum="20.00"
+          Width="250"
+          Value="{Binding Config.Pitch, Mode=TwoWay}" />
+      </StackPanel>
+
+      <!-- Speaking Rate -->
+      <Label
+        Margin="5 10 0 0"
+        MinWidth="100"
+        Padding="0"
+        Content="{DynamicResource GoogleCloudTextToSpeech_SpeakingRate}" />
+      <StackPanel Orientation="Horizontal" Margin="0 0 0 0">
+        <Label
+          Margin="0 0 0 0"
+          MinWidth="60"
+          HorizontalContentAlignment="Right"
+          Content="{Binding ElementName=AllPassSlider, Path=Value, Mode=OneWay}"
+          ContentStringFormat="N2" />
+        <Slider
+          Margin="5 0 0 0"
+          x:Name="AllPassSlider"
+          HorizontalAlignment="Left"
+          VerticalAlignment="Center"
+          SmallChange="0.01"
+          LargeChange="0.01"
+          Minimum="0.25" Maximum="4.00"
+          Width="250"
+          Value="{Binding Config.SpeakingRate, Mode=TwoWay}" />
+      </StackPanel>
+
+      <!-- Sampling Rate Herz -->
+      <Label Content="{DynamicResource GoogleCloudTextToSpeech_SampleRateHertz}" />
+      <ComboBox
+        HorizontalAlignment="Left"
+        MinWidth="350"
+        ItemsSource="{Binding SampleRateHertzList, Mode=OneWay}"
+        DisplayMemberPath="Name"
+        SelectedValuePath="Value"
+        SelectedValue="{Binding Config.SampleRateHertz, Mode=TwoWay}">
+      </ComboBox>
+
+      <TextBlock Margin="5 15 0 0" HorizontalAlignment="Left">
+        <Hyperlink
+          Command="{Binding SetRecommendCommand, Mode=OneWay}">
+          <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_SetRecommend}" />
+        </Hyperlink>
+      </TextBlock>
+
+      <TextBlock
+        Margin="5,20,5,0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap">
+        <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_Discription1}" /><LineBreak />
+        <Hyperlink
+          NavigateUri="https://cloud.google.com/text-to-speech/docs/quickstart-client-libraries"
+          RequestNavigate="OnRequestNavigate"
+          ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=NavigateUri, Mode=OneWay}">
+          <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_DiscriptionRegister}" />
+        </Hyperlink>
+        <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_Discription2}" />
+      </TextBlock>
+
+      <TextBlock
+        Margin="5 20 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_Discription3}" />
+
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleApiCommonProtos}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleApiGax}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleApiGaxGrpc}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleApis}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleApisAuth}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleApisCore}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleCloudTextToSpeechV1}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GoogleProtobuf}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GrpcAuth}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GrpcCore}" />
+      <TextBlock
+        Margin="5 10 5 0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap"
+        Text="{DynamicResource GoogleCloudTextToSpeech_GrpcCoreApi}" />
+
+      <TextBlock
+        Margin="5,20,5,0"
+        HorizontalAlignment="Left"
+        FontSize="14"
+        TextWrapping="Wrap">
+        <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_Discription4}" />
+        <Hyperlink
+          NavigateUri="https://www.nuget.org/packages/Google.Cloud.TextToSpeech.V1/1.0.0/License"
+          RequestNavigate="OnRequestNavigate"
+          ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=NavigateUri, Mode=OneWay}">
+          <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_ApacheLicense}" />
+        </Hyperlink>
+        <TextBlock Text="{DynamicResource GoogleCloudTextToSpeech_Discription5}" />
+      </TextBlock>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigView.xaml.cs
@@ -1,0 +1,36 @@
+﻿using ACT.TTSYukkuri.Config.ViewModels;
+using ACT.TTSYukkuri.resources;
+using FFXIV.Framework.Globalization;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Navigation;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// GoogleCloudTextToSpeechConfigView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class GoogleCloudTextToSpeechConfigView : UserControl, ILocalizable
+    {
+        public GoogleCloudTextToSpeechConfigView()
+        {
+            this.InitializeComponent();
+            this.DataContext = new GoogleCloudTextToSpeechConfigViewModel();
+
+            this.SetLocale(Settings.Default.UILocale);
+        }
+
+        public GoogleCloudTextToSpeechConfigViewModel ViewModel => this.DataContext as GoogleCloudTextToSpeechConfigViewModel;
+
+        public void SetLocale(Locales locale) => this.ReloadLocaleDictionary(locale);
+
+        private async void OnRequestNavigate(
+            object sender,
+            RequestNavigateEventArgs e)
+        {
+            await Task.Run(() => Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri)));
+            e.Handled = true;
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/GoogleCloudTextToSpeech/GoogleCloudTextToSpeechSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/GoogleCloudTextToSpeech/GoogleCloudTextToSpeechSpeechController.cs
@@ -1,0 +1,99 @@
+﻿using ACT.TTSYukkuri.Config;
+using Google.Cloud.TextToSpeech.V1;
+using System;
+using System.IO;
+
+namespace ACT.TTSYukkuri.GoogleCloudTextToSpeech
+{
+    /// <summary>
+    /// Google Cloud Text-to-Speechコントローラ
+    /// </summary>
+    public class GoogleCloudTextToSpeechSpeechController :
+        ISpeechController
+    {
+        private TextToSpeechClient client;
+
+        /// <summary>
+        /// 初期化する
+        /// </summary>
+        public void Initialize()
+        {
+            this.client = TextToSpeechClient.Create();
+        }
+
+        public void Free()
+        {
+            this.client = null;
+        }
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            // 現在の条件をハッシュ化してWAVEファイル名を作る
+            var wave = this.GetCacheFileName(
+                Settings.Default.TTS,
+                text.Replace(Environment.NewLine, "+"),
+                Settings.Default.GoogleCloudTextToSpeechSettings.ToString());
+
+            // Double-checked locking
+            if (!File.Exists(wave))
+            {
+                lock (this)
+                {
+                    if (!File.Exists(wave))
+                    {
+                        // 合成する音声のパラメーターを設定する
+                        SynthesisInput input = new SynthesisInput
+                        {
+                            Text = text
+                        };
+
+                        VoiceSelectionParams voice = new VoiceSelectionParams
+                        {
+                            LanguageCode = Settings.Default.GoogleCloudTextToSpeechSettings.LanguageCode,
+                            Name = Settings.Default.GoogleCloudTextToSpeechSettings.Name,
+                        };
+
+                        AudioConfig config = new AudioConfig
+                        {
+                            AudioEncoding = AudioEncoding.Linear16,
+                            VolumeGainDb = Settings.Default.GoogleCloudTextToSpeechSettings.VolumeGainDb,
+                            Pitch = Settings.Default.GoogleCloudTextToSpeechSettings.Pitch,
+                            SpeakingRate = Settings.Default.GoogleCloudTextToSpeechSettings.SpeakingRate,
+                            SampleRateHertz = Settings.Default.GoogleCloudTextToSpeechSettings.SampleRateHertz,
+                        };
+
+                        // 音声合成リクエストを送信する
+                        var response = client.SynthesizeSpeech(new SynthesizeSpeechRequest
+                        {
+                            Input = input,
+                            Voice = voice,
+                            AudioConfig = config
+                        });
+
+                        // 合成した音声をファイルに書き出す
+                        using (Stream output = File.Create(wave))
+                        {
+                            response.AudioContent.WriteTo(output);
+                        }
+                    }
+                }
+            }
+
+            // 再生する
+            SoundPlayerWrapper.Play(wave, playDevice, isSync, volume);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SpeechController.cs
@@ -1,5 +1,6 @@
 using ACT.TTSYukkuri.Boyomichan;
 using ACT.TTSYukkuri.Config;
+using ACT.TTSYukkuri.GoogleCloudTextToSpeech;
 using ACT.TTSYukkuri.HOYA;
 using ACT.TTSYukkuri.OpenJTalk;
 using ACT.TTSYukkuri.Polly;
@@ -76,6 +77,10 @@ namespace ACT.TTSYukkuri
 
                             case TTSType.SAPI5:
                                 SpeechController.instance = new SAPI5SpeechController();
+                                break;
+
+                            case TTSType.GoogleCloudTextToSpeech:
+                                SpeechController.instance = new GoogleCloudTextToSpeechSpeechController();
                                 break;
 
                             case TTSType.Polly:

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/TTSType.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/TTSType.cs
@@ -46,6 +46,11 @@ namespace ACT.TTSYukkuri
         public const string Polly = "Polly";
 
         /// <summary>
+        /// Google Cloud Text-to-Speech
+        /// </summary>
+        public const string GoogleCloudTextToSpeech = "Google Cloud Text-to-Speech";
+
+        /// <summary>
         /// コンボボックスコレクション
         /// </summary>
         public static ComboBoxItem[] ToComboBox = new ComboBoxItem[]
@@ -58,6 +63,7 @@ namespace ACT.TTSYukkuri
             new ComboBoxItem("CeVIO Creative Studio", TTSType.Sasara),
             new ComboBoxItem("VOICEROID", TTSType.VOICEROID),
             new ComboBoxItem("SAPI5", TTSType.SAPI5),
+            new ComboBoxItem("Google Cloud Text-to-Speech", TTSType.GoogleCloudTextToSpeech),
         };
     }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.en-US.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.en-US.xaml
@@ -96,6 +96,32 @@ For use for commercial purposes, a license to use the library is required.</syst
   <system:String x:Key="SAPI5_Rate">Rate</system:String>
   <system:String x:Key="SAPI5_Pitch">Pitch</system:String>
 
+  <system:String x:Key="GoogleCloudTextToSpeech_Language">Language</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Name">Voice Name</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_VolumeGainDb">Volume [db]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Pitch">Pitch</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SpeakingRate">Speed</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SampleRateHertz">Sampling Rate [Hz]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SetRecommend">Set recommended values</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription1">Google LLCが提供するCloud Text-to-Speechを使用します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_DiscriptionRegister">クイックスタート: クライアント ライブラリの使用</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription2">に従い、サービスアカウントキーが含まれるJSONファイルをダウンロードし、環境変数を設定してください。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription3" xml:space="preserve">本ソフトウェアは、Google LLCの以下のライブラリを使用しており、その著作権は同社に帰属します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiCommonProtos">Google.Api.CommonProtos 1.7.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGax">Google.Api.Gax 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGaxGrpc">Google.Api.Gax.Grpc 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApis">Google.Apis 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisAuth">Google.Apis.Auth 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisCore">Google.Apis.Core 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleCloudTextToSpeechV1">Google.Cloud.TextToSpeech.V1 1.0.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleProtobuf">Google.Protobuf 3.8.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcAuth">Grpc.Auth 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCore">Grpc.Core 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCoreApi">Grpc.Core.Api 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription4" xml:space="preserve">これらのソフトウェアは、</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_ApacheLicense" xml:space="preserve">Apache License Version 2.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription5" xml:space="preserve">の元で配布されています。</system:String>
+
   <system:String x:Key="Polly_Region">Region</system:String>
   <system:String x:Key="Polly_AccessKey">Access Key</system:String>
   <system:String x:Key="Polly_SecretKey">Secret Key</system:String>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ja-JP.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ja-JP.xaml
@@ -96,6 +96,32 @@
   <system:String x:Key="SAPI5_Rate">レート</system:String>
   <system:String x:Key="SAPI5_Pitch">ピッチ</system:String>
 
+  <system:String x:Key="GoogleCloudTextToSpeech_Language">言語</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Name">音声名</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_VolumeGainDb">ボリューム [db]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Pitch">ピッチ</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SpeakingRate">スピード</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SampleRateHertz">サンプリング周波数 [Hz]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SetRecommend">推奨値をセットする</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription1">Google LLCが提供するCloud Text-to-Speechを使用します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_DiscriptionRegister">クイックスタート: クライアント ライブラリの使用</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription2">に従い、サービスアカウントキーが含まれるJSONファイルをダウンロードし、環境変数を設定してください。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription3" xml:space="preserve">本ソフトウェアは、Google LLCの以下のライブラリを使用しており、その著作権は同社に帰属します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiCommonProtos">Google.Api.CommonProtos 1.7.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGax">Google.Api.Gax 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGaxGrpc">Google.Api.Gax.Grpc 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApis">Google.Apis 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisAuth">Google.Apis.Auth 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisCore">Google.Apis.Core 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleCloudTextToSpeechV1">Google.Cloud.TextToSpeech.V1 1.0.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleProtobuf">Google.Protobuf 3.8.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcAuth">Grpc.Auth 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCore">Grpc.Core 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCoreApi">Grpc.Core.Api 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription4" xml:space="preserve">これらのソフトウェアは、</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_ApacheLicense" xml:space="preserve">Apache License Version 2.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription5" xml:space="preserve">の元で配布されています。</system:String>
+
   <system:String x:Key="Polly_Region">リージョン</system:String>
   <system:String x:Key="Polly_AccessKey">アクセスキー</system:String>
   <system:String x:Key="Polly_SecretKey">シークレットキー</system:String>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ko-KR.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ko-KR.xaml
@@ -96,6 +96,32 @@
   <system:String x:Key="SAPI5_Rate">비율</system:String>
   <system:String x:Key="SAPI5_Pitch">피치</system:String>
 
+  <system:String x:Key="GoogleCloudTextToSpeech_Language">Language</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Name">Voice Name</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_VolumeGainDb">Volume [db]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Pitch">Pitch</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SpeakingRate">Speed</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SampleRateHertz">Sampling Rate [Hz]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SetRecommend">권장값 설정</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription1">Google LLCが提供するCloud Text-to-Speechを使用します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_DiscriptionRegister">クイックスタート: クライアント ライブラリの使用</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription2">に従い、サービスアカウントキーが含まれるJSONファイルをダウンロードし、環境変数を設定してください。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription3" xml:space="preserve">本ソフトウェアは、Google LLCの以下のライブラリを使用しており、その著作権は同社に帰属します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiCommonProtos">Google.Api.CommonProtos 1.7.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGax">Google.Api.Gax 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGaxGrpc">Google.Api.Gax.Grpc 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApis">Google.Apis 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisAuth">Google.Apis.Auth 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisCore">Google.Apis.Core 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleCloudTextToSpeechV1">Google.Cloud.TextToSpeech.V1 1.0.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleProtobuf">Google.Protobuf 3.8.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcAuth">Grpc.Auth 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCore">Grpc.Core 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCoreApi">Grpc.Core.Api 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription4" xml:space="preserve">これらのソフトウェアは、</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_ApacheLicense" xml:space="preserve">Apache License Version 2.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription5" xml:space="preserve">の元で配布されています。</system:String>
+
   <system:String x:Key="Polly_Region">지역</system:String>
   <system:String x:Key="Polly_AccessKey">액세스 키</system:String>
   <system:String x:Key="Polly_SecretKey">보안 액세스 키</system:String>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.zh-CN.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.zh-CN.xaml
@@ -96,6 +96,32 @@ For use for commercial purposes, a license to use the library is required.</syst
   <system:String x:Key="SAPI5_Rate">语速</system:String>
   <system:String x:Key="SAPI5_Pitch">紧迫感</system:String>
 
+  <system:String x:Key="GoogleCloudTextToSpeech_Language">Language</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Name">Voice Name</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_VolumeGainDb">Volume [db]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Pitch">Pitch</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SpeakingRate">Speed</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SampleRateHertz">Sampling Rate [Hz]</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_SetRecommend">设为推荐值</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription1">Google LLCが提供するCloud Text-to-Speechを使用します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_DiscriptionRegister">クイックスタート: クライアント ライブラリの使用</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription2">に従い、サービスアカウントキーが含まれるJSONファイルをダウンロードし、環境変数を設定してください。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription3" xml:space="preserve">本ソフトウェアは、Google LLCの以下のライブラリを使用しており、その著作権は同社に帰属します。</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiCommonProtos">Google.Api.CommonProtos 1.7.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGax">Google.Api.Gax 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApiGaxGrpc">Google.Api.Gax.Grpc 2.9.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApis">Google.Apis 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisAuth">Google.Apis.Auth 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleApisCore">Google.Apis.Core 1.40.2</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleCloudTextToSpeechV1">Google.Cloud.TextToSpeech.V1 1.0.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GoogleProtobuf">Google.Protobuf 3.8.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcAuth">Grpc.Auth 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCore">Grpc.Core 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_GrpcCoreApi">Grpc.Core.Api 1.22.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription4" xml:space="preserve">これらのソフトウェアは、</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_ApacheLicense" xml:space="preserve">Apache License Version 2.0</system:String>
+  <system:String x:Key="GoogleCloudTextToSpeech_Discription5" xml:space="preserve">の元で配布されています。</system:String>
+
   <system:String x:Key="Polly_Region">区域</system:String>
   <system:String x:Key="Polly_AccessKey">公钥</system:String>
   <system:String x:Key="Polly_SecretKey">私钥</system:String>


### PR DESCRIPTION
Google Clound Text-to-Speechに対応いたしました。
- UIの文字列は日本語のみ正しく表示されます。ほかの言語については翻訳が不完全です。
- 設定UIにもありますが、使用には登録と設定が必要となります。詳しくは設定UIをご覧ください。
- 本来はGoogle Clound Text-to-Speechの使用料金が発生しますが、無料使用枠があるようです。詳しくは https://cloud.google.com/text-to-speech/ をご覧ください。
- 音声言語を変更した際、音声名コンボボックスの内容を更新するロジックが汚くなってしまいました。きれいに書くにはどうすればよいのでしょう…。
- Google LLCが著作権を持ち、Apache License 2.0で頒布しているライブラリを使用しております。詳しくは設定UIをご覧ください。
- 使用にあたり、grpc_csharp_ext.x64.dllを適切なフォルダに配置する必要があると思います。
