### PR TITLE
Remove UnknownNetworkBuffs as of ACT plugin 2.0.3.1

### DIFF
--- a/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/CombatantEx.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/CombatantEx.cs
@@ -73,9 +73,6 @@ namespace FFXIV.Framework.XIVHelper
             dst.NetworkBuffs.Clear();
             dst.NetworkBuffs.AddRange(src.NetworkBuffs);
 
-            dst.UnknownNetworkBuffs.Clear();
-            dst.UnknownNetworkBuffs.AddRange(src.UnknownNetworkBuffs);
-
             dst.SetName(src.Name);
             SetSkillName(dst);
         }
@@ -132,9 +129,6 @@ namespace FFXIV.Framework.XIVHelper
 
             dst.NetworkBuffs.Clear();
             dst.NetworkBuffs.AddRange(src.NetworkBuffs);
-
-            dst.UnknownNetworkBuffs.Clear();
-            dst.UnknownNetworkBuffs.AddRange(src.UnknownNetworkBuffs);
 
             dst.SetName(src.Name);
             dst.CastSkillName = src.CastSkillName;
@@ -665,11 +659,6 @@ namespace FFXIV.Framework.XIVHelper
         }
 
         public List<NetworkBuff> NetworkBuffs
-        {
-            get;
-        } = new List<NetworkBuff>();
-
-        public List<NetworkBuff> UnknownNetworkBuffs
         {
             get;
         } = new List<NetworkBuff>();


### PR DESCRIPTION
FFXIV ACT plugin version 2.0.3.1 converted NetworkBuff to an field from a property, so the following error is shown in the log:

```2019-08-17 13:04:16.1138 [Error] ThreadWorker - scanFFXIVWorker error. System.MissingMethodException: Method not found: 'System.Collections.Generic.List`1<FFXIV_ACT_Plugin.Common.Models.NetworkBuff> FFXIV_ACT_Plugin.Common.Models.Combatant.get_NetworkBuffs()'.
   at FFXIV.Framework.XIVHelper.CombatantEx.CopyToEx(Combatant source, CombatantEx destination)
   at FFXIV.Framework.XIVHelper.CombatantsManager.RefreshCore(IEnumerable`1 source, Boolean isDummy)
   at FFXIV.Framework.XIVHelper.CombatantsManager.Refresh(IEnumerable`1 source, Boolean isDummy)
   at FFXIV.Framework.XIVHelper.XIVPluginHelper.RefreshCombatantList()
   at FFXIV.Framework.XIVHelper.XIVPluginHelper.<>c__DisplayClass45_0.<Start>b__1()
   at FFXIV.Framework.Common.ThreadWorker.DoWorkLoop()```

If I re-compile the FFXIV.Framework project, direct array access is used (instead of a getter), but the new Combatant object no longer has an UnknownNetworkBuffs property so this PR removes that and also a recompilation will cause direct array access to be used.
