### PR TITLE
Add feature VoicePalettes

### DIFF
--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Models/AdvancedNoticeConfig.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Models/AdvancedNoticeConfig.cs
@@ -75,6 +75,11 @@ namespace ACT.SpecialSpellTimer.Config.Models
             set => this.SetProperty(ref this.toDicordTextChat, value);
         }
 
+        [XmlIgnore]
+        public IEnumerable<VoicePalettes> Palettes => (IEnumerable<VoicePalettes>)Enum.GetValues(typeof(VoicePalettes));
+
+        public VoicePalettes Palette { get; set; } = VoicePalettes.Default;
+
         public void PlayWave(string wave) => PlayWaveCore(wave, this);
 
         public void Speak(string tts) => SyncSpeak(tts, this);
@@ -146,12 +151,12 @@ namespace ACT.SpecialSpellTimer.Config.Models
 
             if (config.ToMainDevice)
             {
-                PlayBridge.Instance.PlayMain(wave, isSync);
+                PlayBridge.Instance.PlayMain(wave, config.Palette, isSync);
             }
 
             if (config.ToSubDevice)
             {
-                PlayBridge.Instance.PlaySub(wave, isSync);
+                PlayBridge.Instance.PlaySub(wave, config.Palette, isSync);
             }
         }
 
@@ -183,12 +188,12 @@ namespace ACT.SpecialSpellTimer.Config.Models
 
             if (config.ToMainDevice)
             {
-                PlayBridge.Instance.PlayMain(tts, isSync);
+                PlayBridge.Instance.PlayMain(tts, config.Palette, isSync);
             }
 
             if (config.ToSubDevice)
             {
-                PlayBridge.Instance.PlaySub(tts, isSync);
+                PlayBridge.Instance.PlaySub(tts, config.Palette, isSync);
             }
 
             if (config.ToDicordTextChat)

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Views/SpellConfigView.xaml
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Views/SpellConfigView.xaml
@@ -794,6 +794,10 @@
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToMainPlaybackDevice}" IsChecked="{Binding Model.MatchAdvancedConfig.ToMainDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToSubPlaybackDevice}" IsChecked="{Binding Model.MatchAdvancedConfig.ToSubDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToDicordTextChannel}" IsChecked="{Binding Model.MatchAdvancedConfig.ToDicordTextChat, Mode=TwoWay}" />
+                      <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                        <Label Margin="0 2 5 0" Content="{DynamicResource Spell_PlayPalette}" />
+                        <ComboBox Width="80" ItemsSource="{Binding Model.MatchAdvancedConfig.Palettes, Mode=OneWay}" SelectedItem="{Binding Model.MatchAdvancedConfig.Palette, Mode=TwoWay}" />
+                      </StackPanel>
                     </StackPanel>
                   </StackPanel>
                 </StackPanel>
@@ -831,6 +835,10 @@
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToMainPlaybackDevice}" IsChecked="{Binding Model.OverAdvancedConfig.ToMainDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToSubPlaybackDevice}" IsChecked="{Binding Model.OverAdvancedConfig.ToSubDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToDicordTextChannel}" IsChecked="{Binding Model.OverAdvancedConfig.ToDicordTextChat, Mode=TwoWay}" />
+                      <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                        <Label Margin="0 2 5 0" Content="{DynamicResource Spell_PlayPalette}" />
+                        <ComboBox Width="80" ItemsSource="{Binding Model.OverAdvancedConfig.Palettes, Mode=OneWay}" SelectedItem="{Binding Model.OverAdvancedConfig.Palette, Mode=TwoWay}" />
+                      </StackPanel>
                     </StackPanel>
                   </StackPanel>
                 </StackPanel>
@@ -868,6 +876,10 @@
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToMainPlaybackDevice}" IsChecked="{Binding Model.BeforeAdvancedConfig.ToMainDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToSubPlaybackDevice}" IsChecked="{Binding Model.BeforeAdvancedConfig.ToSubDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToDicordTextChannel}" IsChecked="{Binding Model.BeforeAdvancedConfig.ToDicordTextChat, Mode=TwoWay}" />
+                      <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                        <Label Margin="0 2 5 0" Content="{DynamicResource Spell_PlayPalette}" />
+                        <ComboBox Width="80" ItemsSource="{Binding Model.BeforeAdvancedConfig.Palettes, Mode=OneWay}" SelectedItem="{Binding Model.BeforeAdvancedConfig.Palette, Mode=TwoWay}" />
+                      </StackPanel>
                     </StackPanel>
                   </StackPanel>
                 </StackPanel>
@@ -901,6 +913,10 @@
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToMainPlaybackDevice}" IsChecked="{Binding Model.TimeupAdvancedConfig.ToMainDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToSubPlaybackDevice}" IsChecked="{Binding Model.TimeupAdvancedConfig.ToSubDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToDicordTextChannel}" IsChecked="{Binding Model.TimeupAdvancedConfig.ToDicordTextChat, Mode=TwoWay}" />
+                      <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                        <Label Margin="0 2 5 0" Content="{DynamicResource Spell_PlayPalette}" />
+                        <ComboBox Width="80" ItemsSource="{Binding Model.TimeupAdvancedConfig.Palettes, Mode=OneWay}" SelectedItem="{Binding Model.TimeupAdvancedConfig.Palette, Mode=TwoWay}" />
+                      </StackPanel>
                     </StackPanel>
                   </StackPanel>
                 </StackPanel>

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Views/TickerConfigView.xaml
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Views/TickerConfigView.xaml
@@ -605,6 +605,10 @@
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToMainPlaybackDevice}" IsChecked="{Binding Model.MatchAdvancedConfig.ToMainDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToSubPlaybackDevice}" IsChecked="{Binding Model.MatchAdvancedConfig.ToSubDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToDicordTextChannel}" IsChecked="{Binding Model.MatchAdvancedConfig.ToDicordTextChat, Mode=TwoWay}" />
+                      <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                        <Label Margin="0 2 5 0" Content="{DynamicResource Spell_PlayPalette}" />
+                        <ComboBox Width="80" ItemsSource="{Binding Model.MatchAdvancedConfig.Palettes, Mode=OneWay}" SelectedItem="{Binding Model.MatchAdvancedConfig.Palette, Mode=TwoWay}" />
+                      </StackPanel>
                     </StackPanel>
                   </StackPanel>
                 </StackPanel>
@@ -638,6 +642,10 @@
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToMainPlaybackDevice}" IsChecked="{Binding Model.DelayAdvancedConfig.ToMainDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToSubPlaybackDevice}" IsChecked="{Binding Model.DelayAdvancedConfig.ToSubDevice, Mode=TwoWay}" />
                       <CheckBox Margin="0 5 0 0" Content="{DynamicResource Spell_ToDicordTextChannel}" IsChecked="{Binding Model.DelayAdvancedConfig.ToDicordTextChat, Mode=TwoWay}" />
+                      <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                        <Label Margin="0 2 5 0" Content="{DynamicResource Spell_PlayPalette}" />
+                        <ComboBox Width="80" ItemsSource="{Binding Model.DelayAdvancedConfig.Palettes, Mode=OneWay}" SelectedItem="{Binding Model.DelayAdvancedConfig.Palette, Mode=TwoWay}" />
+                      </StackPanel>
                     </StackPanel>
                   </StackPanel>
                 </StackPanel>

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.en-US.xaml
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.en-US.xaml
@@ -134,6 +134,7 @@
   <system:String x:Key="Spell_NoticeOnBeforeThisScounds">seconds, Before notify</system:String>
   <system:String x:Key="Spell_UseSequencialTTS">Speak TTS synchronously (Disable simultaneous speak)</system:String>
   <system:String x:Key="Spell_TestSequencialTTS">Test Sync. TTS</system:String>
+  <system:String x:Key="Spell_PlayPalette">Voice config to Notify</system:String>
 
   <system:String x:Key="Ticker_Name">Ticker name</system:String>
   <system:String x:Key="Ticker_Message">Message to display on ticker</system:String>

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.ja-JP.xaml
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.ja-JP.xaml
@@ -134,6 +134,7 @@
   <system:String x:Key="Spell_NoticeOnBeforeThisScounds">秒前に通知する</system:String>
   <system:String x:Key="Spell_UseSequencialTTS">TTSをシンクロ再生する（同時に再生しない）</system:String>
   <system:String x:Key="Spell_TestSequencialTTS">シンクロTTSをテストする</system:String>
+  <system:String x:Key="Spell_PlayPalette">使用する音声設定</system:String>
 
   <system:String x:Key="Ticker_Name">テロップの名前</system:String>
   <system:String x:Key="Ticker_Message">テロップに表示するメッセージ</system:String>

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.ko-KR.xaml
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.ko-KR.xaml
@@ -134,6 +134,7 @@
   <system:String x:Key="Spell_NoticeOnBeforeThisScounds">초 전에 알림</system:String>
   <system:String x:Key="Spell_UseSequencialTTS">TTS 싱크로 재생 (동시에 재생되지 않음)</system:String>
   <system:String x:Key="Spell_TestSequencialTTS">싱크로 TTS 테스트</system:String>
+  <system:String x:Key="Spell_PlayPalette">Voice config to Notify</system:String>
 
   <system:String x:Key="Ticker_Name">티커 이름</system:String>
   <system:String x:Key="Ticker_Message">티커에 표시되는 문자</system:String>

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.zh-CN.xaml
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/resources/strings/Strings.SpeSpe.zh-CN.xaml
@@ -134,6 +134,7 @@
   <system:String x:Key="Spell_NoticeOnBeforeThisScounds">秒前通知</system:String>
   <system:String x:Key="Spell_UseSequencialTTS">按顺序播放TTS (禁止同时播放)</system:String>
   <system:String x:Key="Spell_TestSequencialTTS">测试顺序播放</system:String>
+  <system:String x:Key="Spell_PlayPalette">Voice config to Notify</system:String>
 
   <system:String x:Key="Ticker_Name">字幕名</system:String>
   <system:String x:Key="Ticker_Message">要显示的内容</system:String>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/ACT.TTSYukkuri.Core.csproj
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/ACT.TTSYukkuri.Core.csproj
@@ -123,14 +123,29 @@
     <Compile Include="Config\Views\GeneralView.xaml.cs">
       <DependentUpon>GeneralView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Config\Views\GoogleCloudTextToSpeechConfigTabView.xaml.cs">
+      <DependentUpon>GoogleCloudTextToSpeechConfigTabView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Config\Views\GoogleCloudTextToSpeechConfigView.xaml.cs">
       <DependentUpon>GoogleCloudTextToSpeechConfigView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Config\Views\HoyaConfigTabView.xaml.cs">
+      <DependentUpon>HoyaConfigTabView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Config\Views\HoyaConfigView.xaml.cs">
       <DependentUpon>HoyaConfigView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Config\Views\OpenJTalkConfigTabView.xaml.cs">
+      <DependentUpon>OpenJTalkConfigTabView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Config\Views\PollyConfigTabView.xaml.cs">
+      <DependentUpon>PollyConfigTabView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Config\Views\PollyConfigView.xaml.cs">
       <DependentUpon>PollyConfigView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Config\Views\SAPI5ConfigTabView.xaml.cs">
+      <DependentUpon>SAPI5ConfigTabView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Config\Views\SAPI5ConfigView.xaml.cs">
       <DependentUpon>SAPI5ConfigView.xaml</DependentUpon>
@@ -146,6 +161,9 @@
     </Compile>
     <Compile Include="Config\Views\VoiceroidConfigView.xaml.cs">
       <DependentUpon>VoiceroidConfigView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Config\Views\YukkuriConfigTabView.xaml.cs">
+      <DependentUpon>YukkuriConfigTabView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Config\Views\YukkuriConfigView.xaml.cs">
       <DependentUpon>YukkuriConfigView.xaml</DependentUpon>
@@ -335,7 +353,15 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Config\Views\GoogleCloudTextToSpeechConfigTabView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Config\Views\GoogleCloudTextToSpeechConfigView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Config\Views\HoyaConfigTabView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -343,7 +369,19 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Config\Views\OpenJTalkConfigTabView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Config\Views\PollyConfigTabView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Config\Views\PollyConfigView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Config\Views\SAPI5ConfigTabView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -364,6 +402,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Config\Views\VoiceroidConfigView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Config\Views\YukkuriConfigTabView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Boyomichan/BoyomichanSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Boyomichan/BoyomichanSpeechController.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using ACT.TTSYukkuri.Config;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Boyomichan
 {
@@ -81,6 +82,22 @@ namespace ACT.TTSYukkuri.Boyomichan
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        /// <param name="isSync">使用しない</param>
+        /// <param name="playDevice">使用しない</param>
+        /// <param name="voicePalette">使用しない</param>
+        /// <param name="volume">使用しない</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Settings.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Settings.cs
@@ -81,13 +81,31 @@ namespace ACT.TTSYukkuri.Config
         private string boyomiServer = BoyomichanSpeechController.BoyomichanServer;
         private int boyomiPort = BoyomichanSpeechController.BoyomichanServicePort;
         private YukkuriConfig yukkuriSettings = new YukkuriConfig();
+        private YukkuriConfig yukkuriSettingsExt1 = new YukkuriConfig();
+        private YukkuriConfig yukkuriSettingsExt2 = new YukkuriConfig();
+        private YukkuriConfig yukkuriSettingsExt3 = new YukkuriConfig();
         private HOYAConfig hoyaSettings = new HOYAConfig();
+        private HOYAConfig hoyaSettingsExt1 = new HOYAConfig();
+        private HOYAConfig hoyaSettingsExt2 = new HOYAConfig();
+        private HOYAConfig hoyaSettingsExt3 = new HOYAConfig();
         private PollyConfigs pollySettings = new PollyConfigs();
+        private PollyConfigs pollySettingsExt1 = new PollyConfigs();
+        private PollyConfigs pollySettingsExt2 = new PollyConfigs();
+        private PollyConfigs pollySettingsExt3 = new PollyConfigs();
         private OpenJTalkConfig openJTalkSettings = new OpenJTalkConfig();
+        private OpenJTalkConfig openJTalkSettingsExt1 = new OpenJTalkConfig();
+        private OpenJTalkConfig openJTalkSettingsExt2 = new OpenJTalkConfig();
+        private OpenJTalkConfig openJTalkSettingsExt3 = new OpenJTalkConfig();
         private SasaraConfig sasaraSettings = new SasaraConfig();
         private VoiceroidConfig voiceroidSettings = new VoiceroidConfig();
         private SAPI5Configs sapi5Settings = new SAPI5Configs();
+        private SAPI5Configs sapi5SettingsExt1 = new SAPI5Configs();
+        private SAPI5Configs sapi5SettingsExt2 = new SAPI5Configs();
+        private SAPI5Configs sapi5SettingsExt3 = new SAPI5Configs();
         private GoogleCloudTextToSpeechConfig googleCloudTextToSpeechSettings = new GoogleCloudTextToSpeechConfig();
+        private GoogleCloudTextToSpeechConfig googleCloudTextToSpeechSettingsExt1 = new GoogleCloudTextToSpeechConfig();
+        private GoogleCloudTextToSpeechConfig googleCloudTextToSpeechSettingsExt2 = new GoogleCloudTextToSpeechConfig();
+        private GoogleCloudTextToSpeechConfig googleCloudTextToSpeechSettingsExt3 = new GoogleCloudTextToSpeechConfig();
         private StatusAlertConfig statusAlertSettings = new StatusAlertConfig();
         private DiscordSettings discordSettings = new DiscordSettings();
 
@@ -320,6 +338,21 @@ namespace ACT.TTSYukkuri.Config
             get => this.yukkuriSettings;
             set => this.SetProperty(ref this.yukkuriSettings, value);
         }
+        public YukkuriConfig YukkuriSettingsExt1
+        {
+            get => this.yukkuriSettingsExt1;
+            set => this.SetProperty(ref this.yukkuriSettingsExt1, value);
+        }
+        public YukkuriConfig YukkuriSettingsExt2
+        {
+            get => this.yukkuriSettingsExt2;
+            set => this.SetProperty(ref this.yukkuriSettingsExt2, value);
+        }
+        public YukkuriConfig YukkuriSettingsExt3
+        {
+            get => this.yukkuriSettingsExt3;
+            set => this.SetProperty(ref this.yukkuriSettingsExt3, value);
+        }
 
         /// <summary>
         /// HOYA VoiceTextWebAPI 設定
@@ -329,6 +362,22 @@ namespace ACT.TTSYukkuri.Config
             get => this.hoyaSettings;
             set => this.SetProperty(ref this.hoyaSettings, value);
         }
+        public HOYAConfig HOYASettingsExt1
+        {
+            get => this.hoyaSettingsExt1;
+            set => this.SetProperty(ref this.hoyaSettingsExt1, value);
+        }
+        public HOYAConfig HOYASettingsExt2
+        {
+            get => this.hoyaSettingsExt2;
+            set => this.SetProperty(ref this.hoyaSettingsExt2, value);
+        }
+        public HOYAConfig HOYASettingsExt3
+        {
+            get => this.hoyaSettingsExt3;
+            set => this.SetProperty(ref this.hoyaSettingsExt3, value);
+        }
+
 
         /// <summary>
         /// Amazon Polly VoiceTextWebAPI 設定
@@ -338,6 +387,21 @@ namespace ACT.TTSYukkuri.Config
             get => this.pollySettings;
             set => this.SetProperty(ref this.pollySettings, value);
         }
+        public PollyConfigs PollySettingsExt1
+        {
+            get => this.pollySettingsExt1;
+            set => this.SetProperty(ref this.pollySettingsExt1, value);
+        }
+        public PollyConfigs PollySettingsExt2
+        {
+            get => this.pollySettingsExt2;
+            set => this.SetProperty(ref this.pollySettingsExt2, value);
+        }
+        public PollyConfigs PollySettingsExt3
+        {
+            get => this.pollySettingsExt3;
+            set => this.SetProperty(ref this.pollySettingsExt3, value);
+        }
 
         /// <summary>
         /// OpenJTalk設定
@@ -346,6 +410,21 @@ namespace ACT.TTSYukkuri.Config
         {
             get => this.openJTalkSettings;
             set => this.SetProperty(ref this.openJTalkSettings, value);
+        }
+        public OpenJTalkConfig OpenJTalkSettingsExt1
+        {
+            get => this.openJTalkSettingsExt1;
+            set => this.SetProperty(ref this.openJTalkSettingsExt1, value);
+        }
+        public OpenJTalkConfig OpenJTalkSettingsExt2
+        {
+            get => this.openJTalkSettingsExt2;
+            set => this.SetProperty(ref this.openJTalkSettingsExt2, value);
+        }
+        public OpenJTalkConfig OpenJTalkSettingsExt3
+        {
+            get => this.openJTalkSettingsExt3;
+            set => this.SetProperty(ref this.openJTalkSettingsExt3, value);
         }
 
         /// <summary>
@@ -374,6 +453,21 @@ namespace ACT.TTSYukkuri.Config
             get => this.sapi5Settings;
             set => this.SetProperty(ref this.sapi5Settings, value);
         }
+        public SAPI5Configs SAPI5SettingsExt1
+        {
+            get => this.sapi5SettingsExt1;
+            set => this.SetProperty(ref this.sapi5SettingsExt1, value);
+        }
+        public SAPI5Configs SAPI5SettingsExt2
+        {
+            get => this.sapi5SettingsExt2;
+            set => this.SetProperty(ref this.sapi5SettingsExt2, value);
+        }
+        public SAPI5Configs SAPI5SettingsExt3
+        {
+            get => this.sapi5SettingsExt3;
+            set => this.SetProperty(ref this.sapi5SettingsExt3, value);
+        }
 
         /// <summary>
         /// Google Cloud Text-To-Speechの設定
@@ -383,6 +477,22 @@ namespace ACT.TTSYukkuri.Config
             get => this.googleCloudTextToSpeechSettings;
             set => this.SetProperty(ref this.googleCloudTextToSpeechSettings, value);
         }
+        public GoogleCloudTextToSpeechConfig GoogleCloudTextToSpeechSettingsExt1
+        {
+            get => this.googleCloudTextToSpeechSettingsExt1;
+            set => this.SetProperty(ref this.googleCloudTextToSpeechSettingsExt1, value);
+        }
+        public GoogleCloudTextToSpeechConfig GoogleCloudTextToSpeechSettingsExt2
+        {
+            get => this.googleCloudTextToSpeechSettingsExt2;
+            set => this.SetProperty(ref this.googleCloudTextToSpeechSettingsExt2, value);
+        }
+        public GoogleCloudTextToSpeechConfig GoogleCloudTextToSpeechSettingsExt3
+        {
+            get => this.googleCloudTextToSpeechSettingsExt3;
+            set => this.SetProperty(ref this.googleCloudTextToSpeechSettingsExt3, value);
+        }
+
 
         /// <summary>
         /// オプション設定

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/StatusAlertConfig.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/StatusAlertConfig.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml.Serialization;
 using Prism.Mvvm;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config
 {
@@ -275,8 +276,55 @@ namespace ACT.TTSYukkuri.Config
             set => this.SetProperty(ref this.noticeDeviceForGP, value);
         }
 
+        private VoicePalettes noticeVoicePaletteForHP = FFXIV.Framework.Bridge.VoicePalettes.Default;
+
+        /// <summary>
+        /// HPの通知用設定
+        /// </summary>
+        public VoicePalettes NoticeVoicePaletteForHP
+        {
+            get => this.noticeVoicePaletteForHP;
+            set => this.SetProperty(ref this.noticeVoicePaletteForHP, value);
+        }
+
+        private VoicePalettes noticeVoicePaletteForMP = FFXIV.Framework.Bridge.VoicePalettes.Default;
+
+        /// <summary>
+        /// MPの通知用設定
+        /// </summary>
+        public VoicePalettes NoticeVoicePaletteForMP
+        {
+            get => this.noticeVoicePaletteForMP;
+            set => this.SetProperty(ref this.noticeVoicePaletteForMP, value);
+        }
+
+        private VoicePalettes noticeVoicePaletteForTP = FFXIV.Framework.Bridge.VoicePalettes.Default;
+
+        /// <summary>
+        /// TPの通知用設定
+        /// </summary>
+        public VoicePalettes NoticeVoicePaletteForTP
+        {
+            get => this.noticeVoicePaletteForTP;
+            set => this.SetProperty(ref this.noticeVoicePaletteForTP, value);
+        }
+
+        private VoicePalettes noticeVoicePaletteForGP = FFXIV.Framework.Bridge.VoicePalettes.Default;
+
+        /// <summary>
+        /// GPの通知用設定
+        /// </summary>
+        public VoicePalettes NoticeVoicePaletteForGP
+        {
+            get => this.noticeVoicePaletteForGP;
+            set => this.SetProperty(ref this.noticeVoicePaletteForGP, value);
+        }
+
         [XmlIgnore]
         public IEnumerable<PlayDevices> Devices => (IEnumerable<PlayDevices>)Enum.GetValues(typeof(PlayDevices));
+
+        [XmlIgnore]
+        public IEnumerable<VoicePalettes> Palettes => (IEnumerable<VoicePalettes>)Enum.GetValues(typeof(VoicePalettes));
 
         /// <summary>
         /// アラート対象に初期値をセットする

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GeneralViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GeneralViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -26,6 +28,10 @@ namespace ACT.TTSYukkuri.Config.ViewModels
 
         public ComboBoxItem[] TTSTypes => TTSType.ToComboBox;
 
+        public IEnumerable<VoicePalettes> Palettes => (IEnumerable<VoicePalettes>)Enum.GetValues(typeof(VoicePalettes));
+
+        public VoicePalettes TestPlayPalette { get; set; } = VoicePalettes.Default;
+
         public dynamic[] Players =>
             WavePlayerTypes.WASAPI.GetAvailablePlayers()
             .Select(x => new
@@ -44,7 +50,7 @@ namespace ACT.TTSYukkuri.Config.ViewModels
                     return;
                 }
 
-                PlayBridge.Instance.Play(tts, false, Settings.Default.WaveVolume / 100f);
+                PlayBridge.Instance.Play(tts, TestPlayPalette, false, Settings.Default.WaveVolume / 100f);
             }));
 
         private ICommand openCacheFolderCommand;

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GoogleCloudTextToSpeechViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GoogleCloudTextToSpeechViewModel.cs
@@ -1,11 +1,44 @@
 ﻿using System.Windows.Input;
 using Prism.Commands;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.ViewModels
 {
     public class GoogleCloudTextToSpeechConfigViewModel
     {
-        public GoogleCloudTextToSpeechConfig Config => Settings.Default.GoogleCloudTextToSpeechSettings;
+        VoicePalettes VoicePalette { get; set; }
+
+        public GoogleCloudTextToSpeechConfigViewModel(VoicePalettes voicePalette = VoicePalettes.Default)
+        {
+            this.VoicePalette = voicePalette;
+        }
+
+        public GoogleCloudTextToSpeechConfig Config
+        {
+            get
+            {
+                GoogleCloudTextToSpeechConfig config;
+                switch (VoicePalette)
+                {
+                    case VoicePalettes.Default:
+                        config = Settings.Default.GoogleCloudTextToSpeechSettings;
+                        break;
+                    case VoicePalettes.Ext1:
+                        config = Settings.Default.GoogleCloudTextToSpeechSettingsExt1;
+                        break;
+                    case VoicePalettes.Ext2:
+                        config = Settings.Default.GoogleCloudTextToSpeechSettingsExt2;
+                        break;
+                    case VoicePalettes.Ext3:
+                        config = Settings.Default.GoogleCloudTextToSpeechSettingsExt3;
+                        break;
+                    default:
+                        config = Settings.Default.GoogleCloudTextToSpeechSettings;
+                        break;
+                }
+                return config;
+            }
+        }
 
         public GoogleCloudTextToSpeechLanguageCode[] LanguageCodeList => Settings.Default.GoogleCloudTextToSpeechSettings.EnumerateLanguageCode();
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/HoyaConfigViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/HoyaConfigViewModel.cs
@@ -1,9 +1,41 @@
 using Prism.Mvvm;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.ViewModels
 {
     public class HoyaConfigViewModel : BindableBase
     {
-        public HOYAConfig Config => Settings.Default.HOYASettings;
+        VoicePalettes VoicePalette { get; set; }
+        public HoyaConfigViewModel(VoicePalettes voicePalette = VoicePalettes.Default)
+        {
+            this.VoicePalette = voicePalette;
+        }
+
+        public HOYAConfig Config
+        {
+            get
+            {
+                HOYAConfig config;
+                switch (VoicePalette)
+                {
+                    case VoicePalettes.Default:
+                        config = Settings.Default.HOYASettings;
+                        break;
+                    case VoicePalettes.Ext1:
+                        config = Settings.Default.HOYASettingsExt1;
+                        break;
+                    case VoicePalettes.Ext2:
+                        config = Settings.Default.HOYASettingsExt2;
+                        break;
+                    case VoicePalettes.Ext3:
+                        config = Settings.Default.HOYASettingsExt3;
+                        break;
+                    default:
+                        config = Settings.Default.HOYASettings;
+                        break;
+                }
+                return config;
+            }
+        }
     }
 }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/OpenJTalkConfigViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/OpenJTalkConfigViewModel.cs
@@ -1,12 +1,45 @@
 using System.Windows.Input;
 using Prism.Commands;
 using Prism.Mvvm;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.ViewModels
 {
     public class OpenJTalkConfigViewModel : BindableBase
     {
-        public OpenJTalkConfig Config => Settings.Default.OpenJTalkSettings;
+        VoicePalettes VoicePalette { get; set; }
+
+        public OpenJTalkConfigViewModel(VoicePalettes voicePalette = VoicePalettes.Default)
+        {
+            this.VoicePalette = voicePalette;
+        }
+
+        public OpenJTalkConfig Config
+        {
+            get
+            {
+                OpenJTalkConfig config;
+                switch (VoicePalette)
+                {
+                    case VoicePalettes.Default:
+                        config = Settings.Default.OpenJTalkSettings;
+                        break;
+                    case VoicePalettes.Ext1:
+                        config = Settings.Default.OpenJTalkSettingsExt1;
+                        break;
+                    case VoicePalettes.Ext2:
+                        config = Settings.Default.OpenJTalkSettingsExt2;
+                        break;
+                    case VoicePalettes.Ext3:
+                        config = Settings.Default.OpenJTalkSettingsExt3;
+                        break;
+                    default:
+                        config = Settings.Default.OpenJTalkSettings;
+                        break;
+                }
+                return config;
+            }
+        }
 
         public OpenJTalkVoice[] Voices => Settings.Default.OpenJTalkSettings.EnumerateVoice();
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/PollyConfigViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/PollyConfigViewModel.cs
@@ -5,12 +5,46 @@ using ACT.TTSYukkuri.SAPI5;
 using Amazon;
 using Amazon.Polly;
 using Prism.Mvvm;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.ViewModels
 {
+
     public class PollyConfigViewModel : BindableBase
     {
-        public PollyConfigs Config => Settings.Default.PollySettings;
+        VoicePalettes VoicePalette { get; set; }
+
+        public PollyConfigViewModel(VoicePalettes voicePalette = VoicePalettes.Default)
+        {
+            this.VoicePalette = voicePalette;
+        }
+
+        public PollyConfigs Config
+        {
+            get
+            {
+                PollyConfigs config;
+                switch (VoicePalette)
+                {
+                    case VoicePalettes.Default:
+                        config = Settings.Default.PollySettings;
+                        break;
+                    case VoicePalettes.Ext1:
+                        config = Settings.Default.PollySettingsExt1;
+                        break;
+                    case VoicePalettes.Ext2:
+                        config = Settings.Default.PollySettingsExt2;
+                        break;
+                    case VoicePalettes.Ext3:
+                        config = Settings.Default.PollySettingsExt3;
+                        break;
+                    default:
+                        config = Settings.Default.PollySettings;
+                        break;
+                }
+                return config;
+            }
+        }
 
         public IEnumerable<dynamic> Regions =>
             RegionEndpoint.EnumerableAllRegions

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/SAPI5ConfigViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/SAPI5ConfigViewModel.cs
@@ -2,12 +2,45 @@ using System.Collections.Generic;
 using System.Speech.Synthesis;
 using ACT.TTSYukkuri.SAPI5;
 using Prism.Mvvm;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.ViewModels
 {
     public class SAPI5ConfigViewModel : BindableBase
     {
-        public SAPI5Configs Config => Settings.Default.SAPI5Settings;
+        VoicePalettes VoicePalette { get; set; }
+
+        public SAPI5ConfigViewModel(VoicePalettes voicePalette = VoicePalettes.Default)
+        {
+            this.VoicePalette = voicePalette;
+        }
+
+        public SAPI5Configs Config
+        {
+            get
+            {
+                SAPI5Configs config;
+                switch (VoicePalette)
+                {
+                    case VoicePalettes.Default:
+                        config = Settings.Default.SAPI5Settings;
+                        break;
+                    case VoicePalettes.Ext1:
+                        config = Settings.Default.SAPI5SettingsExt1;
+                        break;
+                    case VoicePalettes.Ext2:
+                        config = Settings.Default.SAPI5SettingsExt2;
+                        break;
+                    case VoicePalettes.Ext3:
+                        config = Settings.Default.SAPI5SettingsExt3;
+                        break;
+                    default:
+                        config = Settings.Default.SAPI5Settings;
+                        break;
+                }
+                return config;
+            }
+        }
 
         public IReadOnlyList<InstalledVoice> Voices => SAPI5SpeechController.Synthesizers;
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/YukkuriConfigViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/YukkuriConfigViewModel.cs
@@ -5,12 +5,45 @@ using System.Windows.Input;
 using ACT.TTSYukkuri.Yukkuri;
 using Prism.Commands;
 using Prism.Mvvm;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.ViewModels
 {
     public class YukkuriConfigViewModel : BindableBase
     {
-        public YukkuriConfig Config => Settings.Default.YukkuriSettings;
+        VoicePalettes VoicePalette { get; set; }
+
+        public YukkuriConfigViewModel(VoicePalettes voicePalette = VoicePalettes.Default)
+        {
+            this.VoicePalette = voicePalette;
+        }
+
+        public YukkuriConfig Config
+        {
+            get
+            {
+                YukkuriConfig config;
+                switch (VoicePalette)
+                {
+                    case VoicePalettes.Default:
+                        config = Settings.Default.YukkuriSettings;
+                        break;
+                    case VoicePalettes.Ext1:
+                        config = Settings.Default.YukkuriSettingsExt1;
+                        break;
+                    case VoicePalettes.Ext2:
+                        config = Settings.Default.YukkuriSettingsExt2;
+                        break;
+                    case VoicePalettes.Ext3:
+                        config = Settings.Default.YukkuriSettingsExt3;
+                        break;
+                    default:
+                        config = Settings.Default.YukkuriSettings;
+                        break;
+                }
+                return config;
+            }
+        }
 
         public IReadOnlyList<AQPreset> Presets => AQVoicePresets.Presets;
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml
@@ -156,13 +156,15 @@
           CornerRadius="2"
           Padding="8">
           <StackPanel Orientation="Vertical">
-            <Label Content="{DynamicResource General_Test}" />
-            <StackPanel Orientation="Horizontal">
-              <TextBox
-                x:Name="TestTextBox"
-                Width="540"
-                VerticalContentAlignment="Center"
-                Text="{DynamicResource General_TestTTS}" />
+            <Label Content="{DynamicResource General_Test}" Padding="0 2"/>
+            <TextBox
+              x:Name="TestTextBox"
+              Width="500"
+              VerticalContentAlignment="Center"
+              HorizontalAlignment="Left"
+              Text="{DynamicResource General_TestTTS}" />
+            <StackPanel Orientation="Horizontal" Margin="0 5 0 0">
+              <ComboBox HorizontalAlignment="Right" Width="80" Margin="380 0 0 0" ItemsSource="{Binding Palettes, Mode=OneWay}" SelectedItem="{Binding TestPlayPalette, Mode=TwoWay}" />
               <Border
                 BorderBrush="DarkGray"
                 BorderThickness="1"

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml.cs
@@ -95,19 +95,19 @@ namespace ACT.TTSYukkuri.Config.Views
                         return;
                     }
 
-                    content = new YukkuriConfigView();
+                    content = new YukkuriConfigTabView();
                     break;
 
                 case TTSType.HOYA:
-                    content = new HoyaConfigView();
+                    content = new HoyaConfigTabView();
                     break;
 
                 case TTSType.Polly:
-                    content = new PollyConfigView();
+                    content = new PollyConfigTabView();
                     break;
 
                 case TTSType.OpenJTalk:
-                    content = new OpenJTalkConfigView();
+                    content = new OpenJTalkConfigTabView();
                     break;
 
                 case TTSType.Sasara:
@@ -152,11 +152,11 @@ namespace ACT.TTSYukkuri.Config.Views
                     break;
 
                 case TTSType.SAPI5:
-                    content = new SAPI5ConfigView();
+                    content = new SAPI5ConfigTabView();
                     break;
 
                 case TTSType.GoogleCloudTextToSpeech:
-                    content = new GoogleCloudTextToSpeechConfigView();
+                    content = new GoogleCloudTextToSpeechConfigTabView();
                     break;
             }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigTabView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigTabView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="ACT.TTSYukkuri.Config.Views.GoogleCloudTextToSpeechConfigTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TabControl Margin="5">
+            <TabItem x:Name="TabDefault" Header="Default"/>
+            <TabItem x:Name="TabExt1" Header="Ext1"/>
+            <TabItem x:Name="TabExt2" Header="Ext2"/>
+            <TabItem x:Name="TabExt3" Header="Ext3"/>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigTabView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigTabView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using FFXIV.Framework.Bridge;
+using System.Windows.Controls;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// GoogleCloudTextToSpeechConfigTabView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class GoogleCloudTextToSpeechConfigTabView : UserControl
+    {
+        public GoogleCloudTextToSpeechConfigTabView()
+        {
+            InitializeComponent();
+            TabDefault.Content = new GoogleCloudTextToSpeechConfigView(VoicePalettes.Default);
+            TabExt1.Content = new GoogleCloudTextToSpeechConfigView(VoicePalettes.Ext1);
+            TabExt2.Content = new GoogleCloudTextToSpeechConfigView(VoicePalettes.Ext2);
+            TabExt3.Content = new GoogleCloudTextToSpeechConfigView(VoicePalettes.Ext3);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GoogleCloudTextToSpeechConfigView.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Navigation;
 using ACT.TTSYukkuri.Config.ViewModels;
 using ACT.TTSYukkuri.resources;
 using FFXIV.Framework.Globalization;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.Views
 {
@@ -13,10 +14,10 @@ namespace ACT.TTSYukkuri.Config.Views
     /// </summary>
     public partial class GoogleCloudTextToSpeechConfigView : UserControl, ILocalizable
     {
-        public GoogleCloudTextToSpeechConfigView()
+        public GoogleCloudTextToSpeechConfigView(VoicePalettes voicePalette = VoicePalettes.Default)
         {
             this.InitializeComponent();
-            this.DataContext = new GoogleCloudTextToSpeechConfigViewModel();
+            this.DataContext = new GoogleCloudTextToSpeechConfigViewModel(voicePalette);
 
             this.SetLocale(Settings.Default.UILocale);
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/HoyaConfigTabView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/HoyaConfigTabView.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl x:Class="ACT.TTSYukkuri.Config.Views.HoyaConfigTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TabControl Margin="5">
+            <TabItem x:Name="TabDefault" Header="Default"/>
+            <TabItem x:Name="TabExt1" Header="Ext1"/>
+            <TabItem x:Name="TabExt2" Header="Ext2"/>
+            <TabItem x:Name="TabExt3" Header="Ext3"/>
+        </TabControl>
+
+    </Grid>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/HoyaConfigTabView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/HoyaConfigTabView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using FFXIV.Framework.Bridge;
+using System.Windows.Controls;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// HoyaConfigTabView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class HoyaConfigTabView : UserControl
+    {
+        public HoyaConfigTabView()
+        {
+            InitializeComponent();
+            TabDefault.Content = new HoyaConfigView(VoicePalettes.Default);
+            TabExt1.Content = new HoyaConfigView(VoicePalettes.Ext1);
+            TabExt2.Content = new HoyaConfigView(VoicePalettes.Ext2);
+            TabExt3.Content = new HoyaConfigView(VoicePalettes.Ext3);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/HoyaConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/HoyaConfigView.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Navigation;
 using ACT.TTSYukkuri.Config.ViewModels;
 using ACT.TTSYukkuri.resources;
 using FFXIV.Framework.Globalization;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.Views
 {
@@ -13,10 +14,10 @@ namespace ACT.TTSYukkuri.Config.Views
     /// </summary>
     public partial class HoyaConfigView : UserControl, ILocalizable
     {
-        public HoyaConfigView()
+        public HoyaConfigView(VoicePalettes voicePalette = VoicePalettes.Default)
         {
             InitializeComponent();
-            this.DataContext = new HoyaConfigViewModel();
+            this.DataContext = new HoyaConfigViewModel(voicePalette);
 
             this.SetLocale(Settings.Default.UILocale);
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/OpenJTalkConfigTabView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/OpenJTalkConfigTabView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="ACT.TTSYukkuri.Config.Views.OpenJTalkConfigTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TabControl Margin="5">
+            <TabItem x:Name="TabDefault" Header="Default"/>
+            <TabItem x:Name="TabExt1" Header="Ext1"/>
+            <TabItem x:Name="TabExt2" Header="Ext2"/>
+            <TabItem x:Name="TabExt3" Header="Ext3"/>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/OpenJTalkConfigTabView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/OpenJTalkConfigTabView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using FFXIV.Framework.Bridge;
+using System.Windows.Controls;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// OpenJTalkConfigTabView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class OpenJTalkConfigTabView : UserControl
+    {
+        public OpenJTalkConfigTabView()
+        {
+            InitializeComponent();
+            TabDefault.Content = new OpenJTalkConfigView(VoicePalettes.Default);
+            TabExt1.Content = new OpenJTalkConfigView(VoicePalettes.Ext1);
+            TabExt2.Content = new OpenJTalkConfigView(VoicePalettes.Ext2);
+            TabExt3.Content = new OpenJTalkConfigView(VoicePalettes.Ext3);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/OpenJTalkConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/OpenJTalkConfigView.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows.Controls;
 using ACT.TTSYukkuri.Config.ViewModels;
 using ACT.TTSYukkuri.resources;
 using FFXIV.Framework.Globalization;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.Views
 {
@@ -10,10 +11,10 @@ namespace ACT.TTSYukkuri.Config.Views
     /// </summary>
     public partial class OpenJTalkConfigView : UserControl, ILocalizable
     {
-        public OpenJTalkConfigView()
+        public OpenJTalkConfigView(VoicePalettes voicePalette = VoicePalettes.Default)
         {
             this.InitializeComponent();
-            this.DataContext = new OpenJTalkConfigViewModel();
+            this.DataContext = new OpenJTalkConfigViewModel(voicePalette);
 
             this.SetLocale(Settings.Default.UILocale);
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/PollyConfigTabView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/PollyConfigTabView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="ACT.TTSYukkuri.Config.Views.PollyConfigTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TabControl Margin="5">
+            <TabItem x:Name="TabDefault" Header="Default"/>
+            <TabItem x:Name="TabExt1" Header="Ext1"/>
+            <TabItem x:Name="TabExt2" Header="Ext2"/>
+            <TabItem x:Name="TabExt3" Header="Ext3"/>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/PollyConfigTabView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/PollyConfigTabView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using FFXIV.Framework.Bridge;
+using System.Windows.Controls;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// PollyConfigTabView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class PollyConfigTabView : UserControl
+    {
+        public PollyConfigTabView()
+        {
+            InitializeComponent();
+            TabDefault.Content = new PollyConfigView(VoicePalettes.Default);
+            TabExt1.Content = new PollyConfigView(VoicePalettes.Ext1);
+            TabExt2.Content = new PollyConfigView(VoicePalettes.Ext2);
+            TabExt3.Content = new PollyConfigView(VoicePalettes.Ext3);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/PollyConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/PollyConfigView.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows.Controls;
 using ACT.TTSYukkuri.Config.ViewModels;
 using ACT.TTSYukkuri.resources;
 using FFXIV.Framework.Globalization;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.Views
 {
@@ -12,10 +13,10 @@ namespace ACT.TTSYukkuri.Config.Views
         UserControl,
         ILocalizable
     {
-        public PollyConfigView()
+        public PollyConfigView(VoicePalettes voicePalette = VoicePalettes.Default)
         {
             this.InitializeComponent();
-            this.DataContext = new PollyConfigViewModel();
+            this.DataContext = new PollyConfigViewModel(voicePalette);
 
             this.SetLocale(Settings.Default.UILocale);
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/SAPI5ConfigTabView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/SAPI5ConfigTabView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="ACT.TTSYukkuri.Config.Views.SAPI5ConfigTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TabControl Margin="5">
+            <TabItem x:Name="TabDefault" Header="Default"/>
+            <TabItem x:Name="TabExt1" Header="Ext1"/>
+            <TabItem x:Name="TabExt2" Header="Ext2"/>
+            <TabItem x:Name="TabExt3" Header="Ext3"/>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/SAPI5ConfigTabView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/SAPI5ConfigTabView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using FFXIV.Framework.Bridge;
+using System.Windows.Controls;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// SAPI5ConfigTabView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class SAPI5ConfigTabView : UserControl
+    {
+        public SAPI5ConfigTabView()
+        {
+            InitializeComponent();
+            TabDefault.Content = new SAPI5ConfigView(VoicePalettes.Default);
+            TabExt1.Content = new SAPI5ConfigView(VoicePalettes.Ext1);
+            TabExt2.Content = new SAPI5ConfigView(VoicePalettes.Ext2);
+            TabExt3.Content = new SAPI5ConfigView(VoicePalettes.Ext3);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/SAPI5ConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/SAPI5ConfigView.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows.Controls;
 using ACT.TTSYukkuri.Config.ViewModels;
 using ACT.TTSYukkuri.resources;
 using FFXIV.Framework.Globalization;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.Views
 {
@@ -12,10 +13,10 @@ namespace ACT.TTSYukkuri.Config.Views
         UserControl,
         ILocalizable
     {
-        public SAPI5ConfigView()
+        public SAPI5ConfigView(VoicePalettes voicePalette = VoicePalettes.Default)
         {
             this.InitializeComponent();
-            this.DataContext = new SAPI5ConfigViewModel();
+            this.DataContext = new SAPI5ConfigViewModel(voicePalette);
 
             this.SetLocale(Settings.Default.UILocale);
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/StatusAlertConfigView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/StatusAlertConfigView.xaml
@@ -96,6 +96,17 @@
 
           <Label
             Margin="0 10 0 0"
+            Padding="0 2"
+            Content="{DynamicResource SA_PlayPalette}" />
+          <ComboBox
+            HorizontalAlignment="Left"
+            Width="80"
+            ItemsSource="{Binding Config.Palettes, Mode=OneWay}"
+            SelectedItem="{Binding Config.NoticeVoicePaletteForHP, Mode=TwoWay}" />
+            
+          <Label
+            Margin="0 10 0 0"
+            Padding="0 2"
             Content="{DynamicResource SA_AlertTarget}" />
           <ItemsControl
               Margin="5 0 5 0"
@@ -157,6 +168,17 @@
             SelectedItem="{Binding Config.NoticeDeviceForMP, Mode=TwoWay}" />
 
           <Label
+            Margin="0 10 0 0"
+            Padding="0 2"
+            Content="{DynamicResource SA_PlayPalette}" />
+          <ComboBox
+            HorizontalAlignment="Left"
+            Width="80"
+            ItemsSource="{Binding Config.Palettes, Mode=OneWay}"
+            SelectedItem="{Binding Config.NoticeVoicePaletteForMP, Mode=TwoWay}" />
+            
+          <Label
+            Padding="0 2"
             Margin="0 10 0 0"
             Content="{DynamicResource SA_AlertTarget}" />
           <ItemsControl
@@ -283,6 +305,17 @@
 
           <Label
             Margin="0 10 0 0"
+            Padding="0 2"
+            Content="{DynamicResource SA_PlayPalette}" />
+          <ComboBox
+            HorizontalAlignment="Left"
+            Width="80"
+            ItemsSource="{Binding Config.Palettes, Mode=OneWay}"
+            SelectedItem="{Binding Config.NoticeVoicePaletteForGP, Mode=TwoWay}" />
+            
+          <Label
+            Margin="0 10 0 0"
+            Padding="0 2"
             Content="{DynamicResource SA_AlertTarget}" />
           <ItemsControl
               Margin="5 0 5 0"

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/YukkuriConfigTabView.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/YukkuriConfigTabView.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="ACT.TTSYukkuri.Config.Views.YukkuriConfigTabView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:ACT.TTSYukkuri.Config.Views"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <TabControl Margin="5">
+            <TabItem x:Name="TabDefault" Header="Default"/>
+            <TabItem x:Name="TabExt1" Header="Ext1"/>
+            <TabItem x:Name="TabExt2" Header="Ext2"/>
+            <TabItem x:Name="TabExt3" Header="Ext3"/>
+        </TabControl>
+    </Grid>
+</UserControl>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/YukkuriConfigTabView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/YukkuriConfigTabView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using FFXIV.Framework.Bridge;
+using System.Windows.Controls;
+
+namespace ACT.TTSYukkuri.Config.Views
+{
+    /// <summary>
+    /// YukkuriConfigTabView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class YukkuriConfigTabView : UserControl
+    {
+        public YukkuriConfigTabView()
+        {
+            InitializeComponent();
+            TabDefault.Content = new YukkuriConfigView(VoicePalettes.Default);
+            TabExt1.Content = new YukkuriConfigView(VoicePalettes.Ext1);
+            TabExt2.Content = new YukkuriConfigView(VoicePalettes.Ext2);
+            TabExt3.Content = new YukkuriConfigView(VoicePalettes.Ext3);
+        }
+    }
+}

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/YukkuriConfigView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/YukkuriConfigView.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Navigation;
 using ACT.TTSYukkuri.Config.ViewModels;
 using ACT.TTSYukkuri.resources;
 using FFXIV.Framework.Globalization;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Config.Views
 {
@@ -13,10 +14,10 @@ namespace ACT.TTSYukkuri.Config.Views
     /// </summary>
     public partial class YukkuriConfigView : UserControl, ILocalizable
     {
-        public YukkuriConfigView()
+        public YukkuriConfigView(VoicePalettes voicePalette = VoicePalettes.Default)
         {
             this.InitializeComponent();
-            this.DataContext = new YukkuriConfigViewModel();
+            this.DataContext = new YukkuriConfigViewModel(voicePalette);
 
             this.SetLocale(Settings.Default.UILocale);
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/FFXIVWatcher.PartyWatcher.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/FFXIVWatcher.PartyWatcher.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using ACT.TTSYukkuri.Config;
 using FFXIV.Framework.Globalization;
 using FFXIV.Framework.XIVHelper;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri
 {
@@ -191,7 +192,7 @@ namespace ACT.TTSYukkuri
                         {
                             if ((DateTime.Now - this.lastHPNotice).TotalSeconds >= NoticeInterval)
                             {
-                                this.Speak(hpTextToSpeak, config.NoticeDeviceForHP);
+                                this.Speak(hpTextToSpeak, config.NoticeDeviceForHP, config.NoticeVoicePaletteForHP);
                                 this.lastHPNotice = DateTime.Now;
                             }
                         }
@@ -199,7 +200,7 @@ namespace ACT.TTSYukkuri
                         {
                             if (hpp <= decimal.Zero && previousePartyMember.HPRate != decimal.Zero)
                             {
-                                this.SpeakEmpty("HP", deadman, config.NoticeDeviceForHP);
+                                this.SpeakEmpty("HP", deadman, config.NoticeDeviceForHP, config.NoticeVoicePaletteForHP);
                                 this.lastHPNotice = DateTime.Now;
                             }
                         }
@@ -219,7 +220,7 @@ namespace ACT.TTSYukkuri
                             {
                                 if ((DateTime.Now - this.lastMPNotice).TotalSeconds >= NoticeInterval)
                                 {
-                                    this.Speak(mpTextToSpeak, config.NoticeDeviceForMP);
+                                    this.Speak(mpTextToSpeak, config.NoticeDeviceForMP, config.NoticeVoicePaletteForMP);
                                     this.lastMPNotice = DateTime.Now;
                                 }
                             }
@@ -227,7 +228,7 @@ namespace ACT.TTSYukkuri
                             {
                                 if (mpp <= decimal.Zero && previousePartyMember.MPRate != decimal.Zero)
                                 {
-                                    this.SpeakEmpty("MP", deadman, config.NoticeDeviceForMP);
+                                    this.SpeakEmpty("MP", deadman, config.NoticeDeviceForMP, config.NoticeVoicePaletteForMP);
                                     this.lastMPNotice = DateTime.Now;
                                 }
                             }
@@ -248,7 +249,7 @@ namespace ACT.TTSYukkuri
                             {
                                 if ((DateTime.Now - this.lastTPNotice).TotalSeconds >= NoticeInterval)
                                 {
-                                    this.Speak(tpTextToSpeak, config.NoticeDeviceForTP);
+                                    this.Speak(tpTextToSpeak, config.NoticeDeviceForTP, config.NoticeVoicePaletteForTP);
                                     this.lastTPNotice = DateTime.Now;
                                 }
                             }
@@ -256,7 +257,7 @@ namespace ACT.TTSYukkuri
                             {
                                 if (tpp <= decimal.Zero && previousePartyMember.TPRate != decimal.Zero)
                                 {
-                                    this.SpeakEmpty("TP", deadman, config.NoticeDeviceForTP);
+                                    this.SpeakEmpty("TP", deadman, config.NoticeDeviceForTP, config.NoticeVoicePaletteForTP);
                                     this.lastTPNotice = DateTime.Now;
                                 }
                             }
@@ -278,7 +279,7 @@ namespace ACT.TTSYukkuri
                             {
                                 if ((DateTime.Now - this.lastGPNotice).TotalSeconds >= NoticeInterval)
                                 {
-                                    this.Speak(gpTextToSpeak, config.NoticeDeviceForGP);
+                                    this.Speak(gpTextToSpeak, config.NoticeDeviceForGP, config.NoticeVoicePaletteForGP);
                                     this.lastGPNotice = DateTime.Now;
                                 }
                             }
@@ -286,7 +287,7 @@ namespace ACT.TTSYukkuri
                             {
                                 if (gpp >= 100m && previousePartyMember.GPRate < 100m)
                                 {
-                                    this.SpeakEmpty("GP", deadman, config.NoticeDeviceForGP);
+                                    this.SpeakEmpty("GP", deadman, config.NoticeDeviceForGP, config.NoticeVoicePaletteForGP);
                                     this.lastGPNotice = DateTime.Now;
                                 }
                             }
@@ -312,7 +313,8 @@ namespace ACT.TTSYukkuri
         private void SpeakEmpty(
             string targetStatus,
             string pcName,
-            PlayDevices device = PlayDevices.Both)
+            PlayDevices device = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default)
         {
             var emptyJa = $"{pcName},{targetStatus}なし。";
             var emptyEn = $"{pcName}, {targetStatus} empty.";
@@ -355,7 +357,7 @@ namespace ACT.TTSYukkuri
                     break;
             }
 
-            this.Speak(tts, device);
+            this.Speak(tts, device, voicePalette);
         }
 
         /// <summary>

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/FFXIVWatcher.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/FFXIVWatcher.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using ACT.TTSYukkuri.Config;
 using FFXIV.Framework.Common;
 using FFXIV.Framework.XIVHelper;
+using FFXIV.Framework.Bridge;
 using NLog;
 
 namespace ACT.TTSYukkuri
@@ -11,7 +12,7 @@ namespace ACT.TTSYukkuri
     /// スピークdelegate
     /// </summary>
     /// <param name="textToSpeak"></param>
-    public delegate void Speak(string textToSpeak, PlayDevices playDevice = PlayDevices.Both, bool isSync = false, float? volume = null);
+    public delegate void Speak(string textToSpeak, PlayDevices playDevice = PlayDevices.Both, VoicePalettes play = VoicePalettes.Default, bool isSync = false, float? volume = null);
 
     /// <summary>
     /// FF14を監視する
@@ -98,7 +99,18 @@ namespace ACT.TTSYukkuri
             string textToSpeak,
             PlayDevices device = PlayDevices.Both,
             bool isSync = false) =>
-            this.SpeakDelegate?.Invoke(textToSpeak, device, isSync);
+            Speak(textToSpeak, device, VoicePalettes.Default, isSync);
+
+        /// <summary>
+        /// スピーク
+        /// </summary>
+        /// <param name="textToSpeak">喋る文字列</param>
+        public void Speak(
+            string textToSpeak,
+            PlayDevices device = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
+            bool isSync = false) =>
+            this.SpeakDelegate?.Invoke(textToSpeak, device, voicePalette, isSync);
 
         public void Start()
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/GoogleCloudTextToSpeech/GoogleCloudTextToSpeechSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/GoogleCloudTextToSpeech/GoogleCloudTextToSpeechSpeechController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using ACT.TTSYukkuri.Config;
 using Google.Cloud.TextToSpeech.V1;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.GoogleCloudTextToSpeech
 {
@@ -31,6 +32,18 @@ namespace ACT.TTSYukkuri.GoogleCloudTextToSpeech
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/ISpeachController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/ISpeachController.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using FFXIV.Framework.Common;
+using FFXIV.Framework.Bridge;
+
 using NLog;
 
 namespace ACT.TTSYukkuri
@@ -27,6 +29,12 @@ namespace ACT.TTSYukkuri
         /// </summary>
         /// <param name="text">読上げるテキスト</param>
         void Speak(string text, PlayDevices playDevice = PlayDevices.Both, bool isSync = false, float? volume = null);
+
+        /// <summary>
+        /// TTSに話してもらう
+        /// </summary>
+        /// <param name="text">読上げるテキスト</param>
+        void Speak(string text, PlayDevices playDevice = PlayDevices.Both, VoicePalettes voicePalette = VoicePalettes.Default, bool isSync = false, float? volume = null);
     }
 
     public static class SpeechControllerExtentions
@@ -67,6 +75,16 @@ namespace ACT.TTSYukkuri
             string text,
             int delay,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => SpeakWithDelay(speechController, text, delay, playDevice, VoicePalettes.Default, isSync, volume);
+
+        public static void SpeakWithDelay(
+            this ISpeechController speechController,
+            string text,
+            int delay,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/OpenJTalk/OpenJTalkSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/OpenJTalk/OpenJTalkSpeechController.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using ACT.TTSYukkuri.Config;
 using NAudio.Wave;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.OpenJTalk
 {
@@ -36,6 +37,18 @@ namespace ACT.TTSYukkuri.OpenJTalk
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/PluginCore.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/PluginCore.cs
@@ -169,6 +169,14 @@ namespace ACT.TTSYukkuri
             PlayDevices playDevice = PlayDevices.Both,
             bool isSync = false,
             float? volume = null)
+            => Speak(message, playDevice, VoicePalettes.Default, isSync, volume);
+
+        public void Speak(
+            string message,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
+            bool isSync = false,
+            float? volume = null)
         {
             if (string.IsNullOrWhiteSpace(message))
             {
@@ -182,7 +190,7 @@ namespace ACT.TTSYukkuri
             {
                 if (!isSync)
                 {
-                    Task.Run(() => this.SpeakTTS(message, playDevice, isSync, volume));
+                    Task.Run(() => this.SpeakTTS(message, playDevice, voicePalette, isSync, volume));
                 }
                 else
                 {
@@ -190,7 +198,7 @@ namespace ACT.TTSYukkuri
                     {
                         lock (TTSBlocker)
                         {
-                            this.SpeakTTS(message, playDevice, isSync, volume);
+                            this.SpeakTTS(message, playDevice, voicePalette, isSync, volume);
                         }
                     });
                 }
@@ -228,6 +236,15 @@ namespace ACT.TTSYukkuri
             PlayDevices playDevice = PlayDevices.Both,
             bool isSync = false,
             float? volume = null)
+            => SpeakTTS(textToSpeak, playDevice, VoicePalettes.Default, isSync, volume);
+
+
+        private void SpeakTTS(
+            string textToSpeak,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
+            bool isSync = false,
+            float? volume = null)
         {
             const string waitCommand = "/wait";
 
@@ -236,7 +253,7 @@ namespace ACT.TTSYukkuri
                 // waitなし？
                 if (!textToSpeak.StartsWith(waitCommand))
                 {
-                    SpeechController.Default.Speak(textToSpeak, playDevice, isSync, volume);
+                    SpeechController.Default.Speak(textToSpeak, playDevice, voicePalette, isSync, volume);
                 }
                 else
                 {
@@ -246,7 +263,7 @@ namespace ACT.TTSYukkuri
                     if (values.Length < 2)
                     {
                         // 普通に読上げて終わる
-                        SpeechController.Default.Speak(textToSpeak, playDevice, isSync, volume);
+                        SpeechController.Default.Speak(textToSpeak, playDevice, voicePalette, isSync, volume);
                         return;
                     }
 
@@ -259,7 +276,7 @@ namespace ACT.TTSYukkuri
                     if (!int.TryParse(delayAsText, out delay))
                     {
                         // 普通に読上げて終わる
-                        SpeechController.Default.Speak(textToSpeak, playDevice, isSync, volume);
+                        SpeechController.Default.Speak(textToSpeak, playDevice, voicePalette, isSync, volume);
                         return;
                     }
 
@@ -399,9 +416,9 @@ namespace ACT.TTSYukkuri
                     });
 
                     // Bridgeにメソッドを登録する
-                    PlayBridge.Instance.SetBothDelegate((message, isSync, volume) => this.Speak(message, PlayDevices.Both, isSync, volume));
-                    PlayBridge.Instance.SetMainDeviceDelegate((message, isSync, volume) => this.Speak(message, PlayDevices.Main, isSync, volume));
-                    PlayBridge.Instance.SetSubDeviceDelegate((message, isSync, volume) => this.Speak(message, PlayDevices.Sub, isSync, volume));
+                    PlayBridge.Instance.SetBothDelegate((message, voicePalette, isSync, volume) => this.Speak(message, PlayDevices.Both, voicePalette, isSync, volume));
+                    PlayBridge.Instance.SetMainDeviceDelegate((message, voicePalette, isSync, volume) => this.Speak(message, PlayDevices.Main, voicePalette, isSync, volume));
+                    PlayBridge.Instance.SetSubDeviceDelegate((message, voicePalette, isSync, volume) => this.Speak(message, PlayDevices.Sub, voicePalette, isSync, volume));
                     PlayBridge.Instance.SetSyncStatusDelegate(() => Settings.Default.Player == WavePlayerTypes.WASAPIBuffered);
 
                     // テキストコマンドの購読を登録する

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Polly/PollySpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Polly/PollySpeechController.cs
@@ -6,6 +6,7 @@ using Amazon.Polly;
 using Amazon.Polly.Model;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Polly
 {
@@ -30,6 +31,18 @@ namespace ACT.TTSYukkuri.Polly
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SAPI5/SAPI5SpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SAPI5/SAPI5SpeechController.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Speech.Synthesis;
 using ACT.TTSYukkuri.Config;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.SAPI5
 {
@@ -113,6 +114,18 @@ namespace ACT.TTSYukkuri.SAPI5
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Sasara/SasaraSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Sasara/SasaraSpeechController.cs
@@ -1,6 +1,7 @@
 using System;
 using ACT.TTSYukkuri.Config;
 using FFXIV.Framework.TTS.Common;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Sasara
 {
@@ -29,6 +30,18 @@ namespace ACT.TTSYukkuri.Sasara
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SpeechController.cs
@@ -8,6 +8,7 @@ using ACT.TTSYukkuri.SAPI5;
 using ACT.TTSYukkuri.Sasara;
 using ACT.TTSYukkuri.Voiceroid;
 using ACT.TTSYukkuri.Yukkuri;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri
 {
@@ -131,6 +132,18 @@ namespace ACT.TTSYukkuri
             PlayDevices playDevice = PlayDevices.Both,
             bool isSync = false,
             float? volume = null)
-            => SpeechController.instance.Speak(text, playDevice, isSync, volume);
+            => SpeechController.instance.Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// TTSに話してもらう
+        /// </summary>
+        /// <param name="text">読上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
+            bool isSync = false,
+            float? volume = null)
+            => SpeechController.instance.Speak(text, playDevice, voicePalette, isSync, volume);
     }
 }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Voiceroid/VoiceroidSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Voiceroid/VoiceroidSpeechController.cs
@@ -7,6 +7,7 @@ using ACT.TTSYukkuri.Config;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using RucheHome.Voiceroid;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Voiceroid
 {
@@ -150,6 +151,18 @@ namespace ACT.TTSYukkuri.Voiceroid
         public async void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => await Task.Run(() => Speak(text, playDevice, VoicePalettes.Default, isSync, volume));
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public async void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Yukkuri/YukkuriSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Yukkuri/YukkuriSpeechController.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using ACT.TTSYukkuri.Config;
 using Advanced_Combat_Tracker;
 using Microsoft.VisualBasic;
+using FFXIV.Framework.Bridge;
 
 namespace ACT.TTSYukkuri.Yukkuri
 {
@@ -52,6 +53,18 @@ namespace ACT.TTSYukkuri.Yukkuri
         public void Speak(
             string text,
             PlayDevices playDevice = PlayDevices.Both,
+            bool isSync = false,
+            float? volume = null)
+            => Speak(text, playDevice, VoicePalettes.Default, isSync, volume);
+
+        /// <summary>
+        /// テキストを読み上げる
+        /// </summary>
+        /// <param name="text">読み上げるテキスト</param>
+        public void Speak(
+            string text,
+            PlayDevices playDevice = PlayDevices.Both,
+            VoicePalettes voicePalette = VoicePalettes.Default,
             bool isSync = false,
             float? volume = null)
         {

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.en-US.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.en-US.xaml
@@ -116,6 +116,7 @@ For use for commercial purposes, a license to use the library is required.</syst
   <system:String x:Key="SA_TTSFormat">Text to Alert</system:String>
   <system:String x:Key="SA_AlertTarget">Alert Targets</system:String>
   <system:String x:Key="SA_Device">Device to Notify</system:String>
+  <system:String x:Key="SA_PlayPalette">Voice config to Notify</system:String>
 
   <system:String x:Key="SA_Discription" xml:space="preserve">
 * Reference for Text to Alert

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ja-JP.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ja-JP.xaml
@@ -116,6 +116,7 @@
   <system:String x:Key="SA_TTSFormat">通知するテキスト</system:String>
   <system:String x:Key="SA_AlertTarget">監視する対象</system:String>
   <system:String x:Key="SA_Device">通知するデバイス</system:String>
+  <system:String x:Key="SA_PlayPalette">使用する音声設定</system:String>
 
   <system:String x:Key="SA_Discription" xml:space="preserve">
 ※通知するテキストの凡例

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ko-KR.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.ko-KR.xaml
@@ -116,6 +116,7 @@
   <system:String x:Key="SA_TTSFormat">경고 텍스트</system:String>
   <system:String x:Key="SA_AlertTarget">감지 대상</system:String>
   <system:String x:Key="SA_Device">알림 재생 장치</system:String>
+  <system:String x:Key="SA_PlayPalette">Voice config to Notify</system:String>
 
   <system:String x:Key="SA_Discription" xml:space="preserve">
 ※경고 텍스트 참조

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.zh-CN.xaml
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/resources/strings/Strings.Yukkuri.zh-CN.xaml
@@ -116,6 +116,7 @@ For use for commercial purposes, a license to use the library is required.</syst
   <system:String x:Key="SA_TTSFormat">警报内容</system:String>
   <system:String x:Key="SA_AlertTarget">警报目标</system:String>
   <system:String x:Key="SA_Device">通过设备</system:String>
+  <system:String x:Key="SA_PlayPalette">Voice config to Notify</system:String>
 
   <system:String x:Key="SA_Discription" xml:space="preserve">
 * 警报内容样例

--- a/source/FFXIV.Framework/FFXIV.Framework/Bridge/PlayBridge.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Bridge/PlayBridge.cs
@@ -2,6 +2,14 @@ using System;
 
 namespace FFXIV.Framework.Bridge
 {
+    public enum VoicePalettes : int
+    {
+        Default = 0,
+        Ext1 = 1,
+        Ext2 = 2,
+        Ext3 = 3,
+    }
+
     public class PlayBridge
     {
         #region Singleton
@@ -19,6 +27,7 @@ namespace FFXIV.Framework.Bridge
 
         public delegate void PlayDevice(
             string message,
+            VoicePalettes voicePalette,
             bool isSync = false,
             float? volume = null);
 
@@ -49,48 +58,63 @@ namespace FFXIV.Framework.Bridge
         #region Play Both
 
         public void Play(string message) =>
-            this.PlayBothDelegate?.Invoke(message, false, null);
+            this.PlayBothDelegate?.Invoke(message, 0, false, null);
 
         public void Play(string message, bool isSync) =>
-            this.PlayBothDelegate?.Invoke(message, isSync, null);
+            this.PlayBothDelegate?.Invoke(message, 0, isSync, null);
 
         public void Play(string message, float? volume) =>
-            this.PlayBothDelegate?.Invoke(message, false, volume);
+            this.PlayBothDelegate?.Invoke(message, 0, false, volume);
 
         public void Play(string message, bool isSync, float? volume) =>
-            this.PlayBothDelegate?.Invoke(message, isSync, volume);
+            this.PlayBothDelegate?.Invoke(message, 0, isSync, volume);
+
+        public void Play(string message, VoicePalettes voicePalette, bool isSync, float? volume) =>
+            this.PlayBothDelegate?.Invoke(message, voicePalette, isSync, volume);
 
         #endregion Play Both
 
         #region Play Main
 
         public void PlayMain(string message) =>
-            this.PlayMainDeviceDelegate?.Invoke(message, false, null);
+            this.PlayMainDeviceDelegate?.Invoke(message, 0, false, null);
 
         public void PlayMain(string message, bool isSync) =>
-            this.PlayMainDeviceDelegate?.Invoke(message, isSync, null);
+            this.PlayMainDeviceDelegate?.Invoke(message, 0, isSync, null);
+
+        public void PlayMain(string message, VoicePalettes voicePalette, bool isSync) =>
+            this.PlayMainDeviceDelegate?.Invoke(message, voicePalette, isSync, null);
 
         public void PlayMain(string message, float? volume) =>
-            this.PlayMainDeviceDelegate?.Invoke(message, false, volume);
+            this.PlayMainDeviceDelegate?.Invoke(message, 0, false, volume);
 
         public void PlayMain(string message, bool isSync, float? volume) =>
-            this.PlayMainDeviceDelegate?.Invoke(message, isSync, volume);
+            this.PlayMainDeviceDelegate?.Invoke(message, 0, isSync, volume);
+
+        public void PlayMain(string message, VoicePalettes voicePalette, bool isSync, float? volume) =>
+            this.PlayMainDeviceDelegate?.Invoke(message, voicePalette, isSync, volume);
 
         #endregion Play Main
 
         #region Play Sub
 
         public void PlaySub(string message) =>
-            this.PlaySubDeviceDelegate?.Invoke(message, false, null);
+            this.PlaySubDeviceDelegate?.Invoke(message, 0, false, null);
 
         public void PlaySub(string message, bool isSync) =>
-            this.PlaySubDeviceDelegate?.Invoke(message, isSync, null);
+            this.PlaySubDeviceDelegate?.Invoke(message, 0, isSync, null);
+
+        public void PlaySub(string message, VoicePalettes voicePalette, bool isSync) =>
+            this.PlaySubDeviceDelegate?.Invoke(message, voicePalette, isSync, null);
 
         public void PlaySub(string message, float? volume) =>
-            this.PlaySubDeviceDelegate?.Invoke(message, false, volume);
+            this.PlaySubDeviceDelegate?.Invoke(message, 0, false, volume);
 
         public void PlaySub(string message, bool isSync, float? volume) =>
-            this.PlaySubDeviceDelegate?.Invoke(message, isSync, volume);
+            this.PlaySubDeviceDelegate?.Invoke(message, 0, isSync, volume);
+
+        public void PlaySub(string message, VoicePalettes voicePalette, bool isSync, float? volume) =>
+            this.PlaySubDeviceDelegate?.Invoke(message, voicePalette, isSync, volume);
 
         #endregion Play Sub
     }


### PR DESCRIPTION
VoicePalettes と名付けた機能の追加です。


## 概要
現状は、TTSYukkuri によって発話される音声の設定は1つだけです。  
男性の声を設定した場合、どのような通知も男性の声で行われます。

VoicePalettes では、単純なステータスの変化や、リキャストの通知といったものを、  
通常とは別の音声や音量、速度で発話させたい場合に対応するために追加しました。
  
たとえば単純なステータスの変化だけを女性の声で通知させることができるようになります。

## 変更点

- 設定を切り替えるための Enum VoicePalettes (Default, Ext1, Ext2, Ext3) を設定
- 複数の発話設定が可能なTTSエンジンに対して、Config の設定パラメータ Ext1, Ext2, Ext3 を追加
- TTSYukkuri の各エンジンの設定UIにTabのViewを追加。４つの設定を切り替え可能に 
- SpeechController の発話メソッド (Speak, Play等) の引数に VoicePalettes を追加
- Bridge 関連の発話メソッドにも引数に VoicePalettes を追加
- TTSYukkuri のHP/MP/GPステータス監視のメニューに Palette を選択するUIを追加
- SpecialSpellTimer の Spell/Ticker の高度な設定に対して、Palette を選択できるようプロパティとUIを追加
