### PR TITLE
Add "refresh all" text command

### DIFF
--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TableCompiler.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TableCompiler.cs
@@ -755,7 +755,7 @@ namespace ACT.SpecialSpellTimer.Models
         }
 #endif
 
-        private void RefreshCombatants()
+        public void RefreshCombatants()
         {
             var player = default(CombatantEx);
             var party = default(IEnumerable<CombatantEx>);

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TextCommandController.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TextCommandController.cs
@@ -19,7 +19,7 @@ namespace ACT.SpecialSpellTimer
         /// コマンド解析用の正規表現
         /// </summary>
         private readonly static Regex regexCommand = new Regex(
-            @".*/spespe (?<command>refresh|changeenabled|set|clear|on|off|pos) ?(?<target>spells|telops|me|pt|pet|placeholder|$) ?(?<windowname>"".*""|all)? ?(?<value>.*)",
+            @".*/spespe (?<command>refresh|changeenabled|set|clear|on|off|pos) ?(?<target>all|spells|telops|me|pt|pet|placeholder|$) ?(?<windowname>"".*""|all)? ?(?<value>.*)",
             RegexOptions.Compiled |
             RegexOptions.IgnoreCase);
 
@@ -104,6 +104,16 @@ namespace ACT.SpecialSpellTimer
                 case "refresh":
                     switch (target)
                     {
+                        case "all":
+                            TableCompiler.Instance.RefreshCombatants();
+                            TableCompiler.Instance.RefreshPlayerPlacceholder();
+                            TableCompiler.Instance.RefreshPartyPlaceholders();
+                            TableCompiler.Instance.RefreshPetPlaceholder();
+                            TableCompiler.Instance.RecompileSpells();
+                            TableCompiler.Instance.RecompileTickers();
+                            r = true;
+                            break;
+
                         case "spells":
                             SpellsController.Instance.ClosePanels();
                             r = true;


### PR DESCRIPTION
パーティリスト上の構成が頻繁に変わるフィールド等、スペスペ内部のパーティリストのプレースホルダが更新されないことがありました。
インゲームのテキストコマンド `/spespe refresh all` で、任意に強制リフレッシュをできるようにしてみました。