### PR TITLE
GoogleCloudTextToSpeechSpeechの初期化時の例外をtry-catchで囲う

### DIFF
--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/GoogleCloudTextToSpeechConfig.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/GoogleCloudTextToSpeechConfig.cs
@@ -18,8 +18,16 @@ namespace ACT.TTSYukkuri.Config
                 return null;
             }
 
-            GoogleCloudTextToSpeechSpeechController.SetupLibrary();
-            return TextToSpeechClient.Create();
+            try
+            {
+                GoogleCloudTextToSpeechSpeechController.SetupLibrary();
+                return TextToSpeechClient.Create();
+            }
+            catch
+            {
+                // Log needed?
+                return null;
+            }
         });
 
         public static TextToSpeechClient TTSClient => LazyClient.Value;


### PR DESCRIPTION
ref: https://github.com/anoyetta/ACT.Hojoring/issues/336

意図せず`GOOGLE_APPLICATION_CREDENTIALS`を読み込んで`Create()`に失敗した場合、YUKKURI自体の初期化失敗するのを回避する修正です。

以下、懸念
- 例外を握り潰しているのでエラーが発生した場合わかりづらくなる
  - ログとかに内容を逃してやりたいがLoggerがおらず
- 当方でACT.Hojoringの完全なビルドができなかった為動作確認ができておらず
