### PR TITLE
bugfix and improvement

### DIFF
--- a/source/ACT.Hojoring.Common/SplashWindow.xaml.cs
+++ b/source/ACT.Hojoring.Common/SplashWindow.xaml.cs
@@ -55,7 +55,7 @@ namespace ACT.Hojoring.Common
             {
                 if (this.SetProperty(ref this.message, value))
                 {
-                    this.FadeOutStartTime = DateTime.Now.Add(SplashDuration);
+                    this.FadeOutStartTime = DateTime.UtcNow.Add(SplashDuration);
                 }
             }
         }
@@ -183,11 +183,11 @@ namespace ACT.Hojoring.Common
 
         public async void StartFadeOut()
         {
-            this.FadeOutStartTime = DateTime.Now.Add(SplashDuration);
+            this.FadeOutStartTime = DateTime.UtcNow.Add(SplashDuration);
 
             await Task.Run(async () =>
             {
-                while (DateTime.Now <= this.FadeOutStartTime || this.IsSustainFadeOut)
+                while (DateTime.UtcNow <= this.FadeOutStartTime || this.IsSustainFadeOut)
                 {
                     await Task.Delay(200);
                 }

--- a/source/ACT.SpecialSpellTimer.RazorModel/TimelineScriptGlobalModel.cs
+++ b/source/ACT.SpecialSpellTimer.RazorModel/TimelineScriptGlobalModel.cs
@@ -220,7 +220,7 @@ namespace ACT.SpecialSpellTimer.RazorModel
         {
             lock (this.ScriptingBlocker)
             {
-                var now = DateTime.Now;
+                var now = DateTime.UtcNow;
 
                 var scripts = this.Scripts.Where(x =>
                 {
@@ -264,7 +264,7 @@ namespace ACT.SpecialSpellTimer.RazorModel
         {
             lock (this.ScriptingBlocker)
             {
-                var now = DateTime.Now;
+                //var now = DateTime.UtcNow;
 
 #if DEBUG
                 if (currentSubRoutine == "応用フェーズ")

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Models/AdvancedNoticeConfig.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Models/AdvancedNoticeConfig.cs
@@ -246,7 +246,7 @@ namespace ACT.SpecialSpellTimer.Config.Models
                 var interval = Settings.Default.WaitingTimeToSyncTTS / 4d;
 
                 SyncList.Add(new SyncTTS(SyncList.Count, priority, tts, config));
-                SyncListTimestamp = DateTime.Now;
+                SyncListTimestamp = DateTime.UtcNow;
                 SyncListCount = SyncList.Count;
 
                 SyncSpeakTimer.Interval = interval;
@@ -271,7 +271,7 @@ namespace ACT.SpecialSpellTimer.Config.Models
             var syncs = default(IEnumerable<SyncTTS>);
             lock (SyncList)
             {
-                if ((DateTime.Now - SyncListTimestamp).TotalMilliseconds < Settings.Default.WaitingTimeToSyncTTS)
+                if ((DateTime.UtcNow - SyncListTimestamp).TotalMilliseconds < Settings.Default.WaitingTimeToSyncTTS)
                 {
                     return;
                 }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Settings.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Settings.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Interop;
 using System.Xml;
 using System.Xml.Serialization;
@@ -105,7 +106,7 @@ namespace ACT.SpecialSpellTimer.Config
                         }
                         else
                         {
-                            button.BackColor = SystemColors.Control;
+                            button.BackColor = System.Drawing.SystemColors.Control;
                             button.ForeColor = Color.Black;
                         }
                     }
@@ -783,16 +784,43 @@ namespace ACT.SpecialSpellTimer.Config
                     return;
                 }
 
-                using (var sr = new StreamReader(this.FileName, new UTF8Encoding(false)))
+                try
                 {
-                    if (sr.BaseStream.Length > 0)
+                    using (var sr = new StreamReader(this.FileName, new UTF8Encoding(false)))
                     {
-                        var xs = new XmlSerializer(this.GetType());
-                        var data = xs.Deserialize(sr) as Settings;
-                        if (data != null)
+                        if (sr.BaseStream.Length > 0)
                         {
-                            instance = data;
-                            instance.isLoaded = true;
+                            var xs = new XmlSerializer(this.GetType());
+                            var data = xs.Deserialize(sr) as Settings;
+                            if (data != null)
+                            {
+                                instance = data;
+                                instance.isLoaded = true;
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                    info += ex.Message + Environment.NewLine;
+                    info += ex.StackTrace.ToString();
+
+                    if (ex.InnerException != null)
+                    {
+                        info += Environment.NewLine + Environment.NewLine;
+                        info += "Inner Exception :" + Environment.NewLine;
+                        info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                        info += ex.InnerException.Message + Environment.NewLine;
+                        info += ex.InnerException.StackTrace.ToString();
+                    }
+
+                    var result = MessageBox.Show("faild config load\n\n" + FileName + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        if (EnvironmentHelper.RestoreFile(FileName))
+                        {
+                            Load();
                         }
                     }
                 }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Settings.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Config/Settings.cs
@@ -724,9 +724,9 @@ namespace ACT.SpecialSpellTimer.Config
                 DateTime d;
                 if (DateTime.TryParse(value, out d))
                 {
-                    if (d > DateTime.Now)
+                    if (d > DateTime.UtcNow)
                     {
-                        d = DateTime.Now;
+                        d = DateTime.UtcNow;
                     }
 
                     this.lastUpdateDateTime = d;
@@ -738,9 +738,9 @@ namespace ACT.SpecialSpellTimer.Config
                     var decrypt = Crypter.DecryptString(value);
                     if (DateTime.TryParse(decrypt, out d))
                     {
-                        if (d > DateTime.Now)
+                        if (d > DateTime.UtcNow)
                         {
-                            d = DateTime.Now;
+                            d = DateTime.UtcNow;
                         }
 
                         this.lastUpdateDateTime = d;
@@ -863,7 +863,7 @@ namespace ACT.SpecialSpellTimer.Config
         {
             this.PropertyChanged += async (_, __) =>
             {
-                var now = DateTime.Now;
+                var now = DateTime.UtcNow;
 
                 if ((now - this.lastAutoSaveTimestamp).TotalSeconds > 20)
                 {

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/Spell.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/Spell.cs
@@ -1183,12 +1183,12 @@ namespace ACT.SpecialSpellTimer.Models
 
         public void StartMatching()
         {
-            this.matchingStartDateTime = DateTime.Now;
+            this.matchingStartDateTime = DateTime.UtcNow;
         }
 
         public void EndMatching()
         {
-            var ticks = (DateTime.Now - this.matchingStartDateTime).Ticks;
+            var ticks = (DateTime.UtcNow - this.matchingStartDateTime).Ticks;
             if (ticks == 0)
             {
                 return;

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/SpellPanelTable.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/SpellPanelTable.cs
@@ -4,8 +4,10 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Xml.Serialization;
 using ACT.SpecialSpellTimer.Config;
+using FFXIV.Framework.Common;
 
 namespace ACT.SpecialSpellTimer.Models
 {
@@ -110,6 +112,29 @@ namespace ACT.SpecialSpellTimer.Models
 
                                 this.table.Add(x);
                             }
+                        }
+                    }
+                } catch (Exception ex)
+                {
+                    var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                    info += ex.Message + Environment.NewLine;
+                    info += ex.StackTrace.ToString();
+
+                    if (ex.InnerException != null)
+                    {
+                        info += Environment.NewLine + Environment.NewLine;
+                        info += "Inner Exception :" + Environment.NewLine;
+                        info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                        info += ex.InnerException.Message + Environment.NewLine;
+                        info += ex.InnerException.StackTrace.ToString();
+                    }
+
+                    var result = MessageBox.Show("faild config load\n\n" + DefaultFile + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        if (EnvironmentHelper.RestoreFile(DefaultFile))
+                        {
+                            Load();
                         }
                     }
                 }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/SpellTable.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/SpellTable.cs
@@ -5,7 +5,9 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Xml.Serialization;
+using FFXIV.Framework.Common;
 using FFXIV.Framework.Extensions;
 
 namespace ACT.SpecialSpellTimer.Models
@@ -202,6 +204,29 @@ namespace ACT.SpecialSpellTimer.Models
 
                             this.table.Add(item);
                         }
+                    }
+                }
+            } catch (Exception ex)
+            {
+                var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                info += ex.Message + Environment.NewLine;
+                info += ex.StackTrace.ToString();
+
+                if (ex.InnerException != null)
+                {
+                    info += Environment.NewLine + Environment.NewLine;
+                    info += "Inner Exception :" + Environment.NewLine;
+                    info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                    info += ex.InnerException.Message + Environment.NewLine;
+                    info += ex.InnerException.StackTrace.ToString();
+                }
+
+                var result = MessageBox.Show("faild config load\n\n" + DefaultFile + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                if (result == MessageBoxResult.Yes)
+                {
+                    if (EnvironmentHelper.RestoreFile(DefaultFile))
+                    {
+                        Load();
                     }
                 }
             }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TableCompiler.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TableCompiler.cs
@@ -88,7 +88,7 @@ namespace ACT.SpecialSpellTimer.Models
 
         public event EventHandler CompileConditionChanged;
 
-        private DateTime lastDumpPositionTimestamp = DateTime.Now.AddMinutes(5);
+        private DateTime lastDumpPositionTimestamp = DateTime.UtcNow.AddMinutes(5);
 
         private bool isQueueRecompile = false;
         private bool isQueueZoneChange = false;
@@ -128,7 +128,7 @@ namespace ACT.SpecialSpellTimer.Models
                     SharlayanHelper.Instance.EnqueueReload();
 
                     this.isQueueRecompile = true;
-                    this.lastQueueTimestamp = DateTime.Now;
+                    this.lastQueueTimestamp = DateTime.UtcNow;
                 }
             }
 
@@ -138,7 +138,7 @@ namespace ACT.SpecialSpellTimer.Models
                 {
                     this.isQueueRecompile = true;
                     this.isQueueZoneChange = true;
-                    this.lastQueueTimestamp = DateTime.Now;
+                    this.lastQueueTimestamp = DateTime.UtcNow;
                 }
             }
         }
@@ -147,7 +147,7 @@ namespace ACT.SpecialSpellTimer.Models
         {
             lock (this)
             {
-                if ((DateTime.Now - this.lastQueueTimestamp).TotalMilliseconds <= CompileHandlerInterval)
+                if ((DateTime.UtcNow - this.lastQueueTimestamp).TotalMilliseconds <= CompileHandlerInterval)
                 {
                     return;
                 }
@@ -228,9 +228,9 @@ namespace ACT.SpecialSpellTimer.Models
             LogBuffer.DumpMyPetDistance();
 
             // 定期的に自分の座標をダンプする
-            if ((DateTime.Now - this.lastDumpPositionTimestamp).TotalSeconds >= 60.0)
+            if ((DateTime.UtcNow - this.lastDumpPositionTimestamp).TotalSeconds >= 60.0)
             {
-                this.lastDumpPositionTimestamp = DateTime.Now;
+                this.lastDumpPositionTimestamp = DateTime.UtcNow;
                 LogBuffer.DumpPosition(true);
             }
         }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TagTable.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TagTable.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Xml.Serialization;
 using FFXIV.Framework.Common;
 using Prism.Mvvm;
@@ -108,6 +109,29 @@ namespace ACT.SpecialSpellTimer.Models
 
                             this.ItemTags.AddRange(data.ItemTags);
                             this.Tags.AddRange(data.Tags);
+                        }
+                    }
+                } catch (Exception ex)
+                {
+                    var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                    info += ex.Message + Environment.NewLine;
+                    info += ex.StackTrace.ToString();
+
+                    if (ex.InnerException != null)
+                    {
+                        info += Environment.NewLine + Environment.NewLine;
+                        info += "Inner Exception :" + Environment.NewLine;
+                        info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                        info += ex.InnerException.Message + Environment.NewLine;
+                        info += ex.InnerException.StackTrace.ToString();
+                    }
+
+                    var result = MessageBox.Show("faild config load\n\n" + DefaultFile + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        if (EnvironmentHelper.RestoreFile(DefaultFile))
+                        {
+                            Load();
                         }
                     }
                 }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/Ticker.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/Ticker.cs
@@ -522,12 +522,12 @@ namespace ACT.SpecialSpellTimer.Models
 
         public void StartMatching()
         {
-            this.matchingStartDateTime = DateTime.Now;
+            this.matchingStartDateTime = DateTime.UtcNow;
         }
 
         public void EndMatching()
         {
-            var ticks = (DateTime.Now - this.matchingStartDateTime).Ticks;
+            var ticks = (DateTime.UtcNow - this.matchingStartDateTime).Ticks;
             if (ticks == 0)
             {
                 return;
@@ -582,7 +582,7 @@ namespace ACT.SpecialSpellTimer.Models
             }
 
             var timeToPlay = this.MatchDateTime.AddSeconds(this.Delay);
-            var duration = (timeToPlay - DateTime.Now).TotalMilliseconds;
+            var duration = (timeToPlay - DateTime.UtcNow).TotalMilliseconds;
 
             if (duration > 0d)
             {
@@ -686,7 +686,7 @@ namespace ACT.SpecialSpellTimer.Models
 
         public void SimulateMatch()
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
 
             // 擬似的にマッチ状態にする
             this.IsTest = true;

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TickerTable.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/TickerTable.cs
@@ -5,7 +5,9 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Xml.Serialization;
+using FFXIV.Framework.Common;
 using FFXIV.Framework.Extensions;
 
 namespace ACT.SpecialSpellTimer.Models
@@ -131,6 +133,29 @@ namespace ACT.SpecialSpellTimer.Models
                         {
                             this.table.Add(item);
                         }
+                    }
+                }
+            } catch (Exception ex)
+            {
+                var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                info += ex.Message + Environment.NewLine;
+                info += ex.StackTrace.ToString();
+
+                if (ex.InnerException != null)
+                {
+                    info += Environment.NewLine + Environment.NewLine;
+                    info += "Inner Exception :" + Environment.NewLine;
+                    info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                    info += ex.InnerException.Message + Environment.NewLine;
+                    info += ex.InnerException.StackTrace.ToString();
+                }
+
+                var result = MessageBox.Show("faild config load\n\n" + DefaultFile + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                if (result == MessageBoxResult.Yes)
+                {
+                    if (EnvironmentHelper.RestoreFile(DefaultFile))
+                    {
+                        Load();
                     }
                 }
             }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/ParsedLogWorker.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/ParsedLogWorker.cs
@@ -190,13 +190,13 @@ namespace ACT.SpecialSpellTimer
 
                 if (!isForceFlush)
                 {
-                    if ((DateTime.Now - this.lastFlushTimestamp) < FlushInterval)
+                    if ((DateTime.UtcNow - this.lastFlushTimestamp) < FlushInterval)
                     {
                         return;
                     }
                 }
 
-                this.lastFlushTimestamp = DateTime.Now;
+                this.lastFlushTimestamp = DateTime.UtcNow;
 
                 lock (this)
                 {

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/PluginMainWorker.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/PluginMainWorker.cs
@@ -59,7 +59,7 @@ namespace ACT.SpecialSpellTimer
 
         public bool IsFFXIVActive => XIVPluginHelper.Instance.IsFFXIVActive;
 
-        private DateTime lastSaveTickerTableDateTime = DateTime.Now;
+        private DateTime lastSaveTickerTableDateTime = DateTime.UtcNow;
 
         public LogBuffer LogBuffer { get; private set; }
 
@@ -256,9 +256,9 @@ namespace ACT.SpecialSpellTimer
                 XIVPluginHelper.Instance.CurrentFFXIVProcess != null &&
                 !XIVPluginHelper.Instance.CurrentFFXIVProcess.HasExited;
 
-            if ((DateTime.Now - this.lastSaveTickerTableDateTime).TotalMinutes >= 1)
+            if ((DateTime.UtcNow - this.lastSaveTickerTableDateTime).TotalMinutes >= 1)
             {
-                this.lastSaveTickerTableDateTime = DateTime.Now;
+                this.lastSaveTickerTableDateTime = DateTime.UtcNow;
 
                 if (this.existFFXIVProcess)
                 {

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/CombatAnalyzer.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/CombatAnalyzer.cs
@@ -180,6 +180,14 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
             bool isImport,
             LogLineEventArgs logInfo)
         {
+#if true
+            if (!Settings.Default.AutoCombatLogAnalyze)
+            {
+                return;
+            }
+
+            this.logInfoQueue.Enqueue(logInfo);
+#else
             try
             {
                 if (!Settings.Default.AutoCombatLogAnalyze)
@@ -195,6 +203,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                     "catch exception at Timeline Analyzer OnLogLineRead.",
                     ex);
             }
+#endif
         }
 
         #region PC Name

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineController.Notice.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineController.Notice.cs
@@ -121,7 +121,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                 return;
             }
 
-            var now = DateTime.Now;
+            //var now = DateTime.Now;
             var offset = this.CurrentTime - act.Time;
 
             var from = new[] { act.Name, act.TextReplaced, act.SyncKeyword }.FirstOrDefault(x => !string.IsNullOrEmpty(x));
@@ -249,7 +249,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                 return;
             }
 
-            var now = DateTime.Now;
+            //var now = DateTime.Now;
 
             var from = new[] { tri.Name, tri.TextReplaced, tri.SyncKeyword }.FirstOrDefault(x => !string.IsNullOrEmpty(x));
             var log = $"{TimelineConstants.LogSymbol} notice \"{tri.NoticeReplaced}\" from \"{from}\"";

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineExpressionsModel.Global.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineExpressionsModel.Global.cs
@@ -45,9 +45,9 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                         TimelineController.RaiseLog(
                             $"{TimelineConstants.LogSymbol} set VAR['{name}'] = {value}");
 
-                        if ((DateTime.Now - totChangedTimestamp) > TimeSpan.FromSeconds(2))
+                        if ((DateTime.UtcNow - totChangedTimestamp) > TimeSpan.FromSeconds(2))
                         {
-                            totChangedTimestamp = DateTime.Now;
+                            totChangedTimestamp = DateTime.UtcNow;
                             TimelineController.RaiseLog(
                                 $"Target-of-Target has been changed.");
                         }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineScriptModel.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineScriptModel.cs
@@ -255,7 +255,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
             }
             finally
             {
-                this.LastExecutedTimestamp = DateTime.Now;
+                this.LastExecutedTimestamp = DateTime.UtcNow;
             }
 
             return result;

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineSettings.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/TimelineSettings.cs
@@ -559,6 +559,29 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
                             data = xs.Deserialize(sr) as TimelineSettings;
                         }
                     }
+                } catch (Exception ex)
+                {
+                    var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                    info += ex.Message + Environment.NewLine;
+                    info += ex.StackTrace.ToString();
+
+                    if (ex.InnerException != null)
+                    {
+                        info += Environment.NewLine + Environment.NewLine;
+                        info += "Inner Exception :" + Environment.NewLine;
+                        info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                        info += ex.InnerException.Message + Environment.NewLine;
+                        info += ex.InnerException.StackTrace.ToString();
+                    }
+
+                    var result = MessageBox.Show("faild config load\n\n" + file + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                    if (result == MessageBoxResult.Yes)
+                    {
+                        if (EnvironmentHelper.RestoreFile(file))
+                        {
+                            Load();
+                        }
+                    }
                 }
                 finally
                 {

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TickersController.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TickersController.cs
@@ -272,10 +272,11 @@ namespace ACT.SpecialSpellTimer
 
                 if (telop.MatchDateTime > DateTime.MinValue)
                 {
+                    var now = DateTime.Now;
                     var start = telop.MatchDateTime.AddSeconds(telop.Delay);
                     var end = telop.MatchDateTime.AddSeconds(telop.Delay + telop.DisplayTime);
 
-                    if (start <= DateTime.Now && DateTime.Now <= end)
+                    if (start <= now && now <= end)
                     {
                         w.Refresh();
                         w.ShowOverlay();
@@ -285,7 +286,7 @@ namespace ACT.SpecialSpellTimer
                     {
                         w.HideOverlay();
 
-                        if (DateTime.Now > end)
+                        if (now > end)
                         {
                             telop.MatchDateTime = DateTime.MinValue;
                             telop.MessageReplaced = string.Empty;

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Utility/ConditionUtility.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Utility/ConditionUtility.cs
@@ -157,10 +157,11 @@ namespace ACT.SpecialSpellTimer.Utility
         {
             if (telop.MatchDateTime > DateTime.MinValue && !telop.ForceHide)
             {
+                var now = DateTime.Now;
                 var start = telop.MatchDateTime.AddSeconds(telop.Delay);
                 var end = telop.MatchDateTime.AddSeconds(telop.Delay + telop.DisplayTime);
 
-                if (start <= DateTime.Now && DateTime.Now <= end)
+                if (start <= now && now <= end)
                 {
                     return true;
                 }

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Views/AdvancedSpellPanelWindow.xaml.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Views/AdvancedSpellPanelWindow.xaml.cs
@@ -321,6 +321,7 @@ namespace ACT.SpecialSpellTimer.Views
                 controls = this.spellControls.ToArray();
             }
 
+            var now = DateTime.Now;
             var isActive = false;
             foreach (var control in controls)
             {
@@ -336,7 +337,7 @@ namespace ACT.SpecialSpellTimer.Views
                     }
                     else
                     {
-                        if ((DateTime.Now - spell.CompleteScheduledTime).TotalSeconds > 1.0d)
+                        if ((now - spell.CompleteScheduledTime).TotalSeconds > 1.0d)
                         {
                             spell.MatchDateTime = DateTime.MinValue;
                         }
@@ -352,7 +353,7 @@ namespace ACT.SpecialSpellTimer.Views
                 }
                 else
                 {
-                    control.RecastTime = (spell.CompleteScheduledTime - DateTime.Now).TotalSeconds;
+                    control.RecastTime = (spell.CompleteScheduledTime - now).TotalSeconds;
                     if (control.RecastTime < 0)
                     {
                         control.RecastTime = 0;

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Views/SpellPanelWindow.xaml.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Views/SpellPanelWindow.xaml.cs
@@ -373,6 +373,7 @@ namespace ACT.SpecialSpellTimer.Views
                 controls = this.spellControls.ToArray();
             }
 
+            var now = DateTime.Now;
             var isActive = false;
             foreach (var control in controls)
             {
@@ -388,7 +389,7 @@ namespace ACT.SpecialSpellTimer.Views
                     }
                     else
                     {
-                        if ((DateTime.Now - spell.CompleteScheduledTime).TotalSeconds > 1.0d)
+                        if ((now - spell.CompleteScheduledTime).TotalSeconds > 1.0d)
                         {
                             spell.MatchDateTime = DateTime.MinValue;
                         }
@@ -404,7 +405,7 @@ namespace ACT.SpecialSpellTimer.Views
                 }
                 else
                 {
-                    control.RecastTime = (spell.CompleteScheduledTime - DateTime.Now).TotalSeconds;
+                    control.RecastTime = (spell.CompleteScheduledTime - now).TotalSeconds;
                     if (control.RecastTime < 0)
                     {
                         control.RecastTime = 0;

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Boyomichan/BoyomichanSpeechController.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Boyomichan/BoyomichanSpeechController.cs
@@ -130,14 +130,14 @@ namespace ACT.TTSYukkuri.Boyomichan
             }
 
             if (this.lastText == text &&
-                (DateTime.Now - this.lastTextTimestamp).TotalSeconds
+                (DateTime.UtcNow - this.lastTextTimestamp).TotalSeconds
                 <= Settings.Default.GlobalSoundInterval)
             {
                 return;
             }
 
             this.lastText = text;
-            this.lastTextTimestamp = DateTime.Now;
+            this.lastTextTimestamp = DateTime.UtcNow;
 
             this.Queue.Enqueue(text.Trim());
         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/CevioAIConfig.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/CevioAIConfig.cs
@@ -24,7 +24,7 @@ namespace ACT.TTSYukkuri.Config
     {
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -343,11 +343,11 @@ namespace ACT.TTSYukkuri.Config
             switch (result)
             {
                 case HostStartResult.Succeeded:
-                    this.Logger.Info($"CeVIO RPC start.");
+                    this.AppLogger.Info($"CeVIO RPC start.");
                     break;
 
                 case HostStartResult.AlreadyStarted:
-                    this.Logger.Info($"CeVIO RPC already started, connect to CeVIO.");
+                    this.AppLogger.Info($"CeVIO RPC already started, connect to CeVIO.");
                     break;
 
                 case HostStartResult.NotRegistered:
@@ -439,7 +439,7 @@ namespace ACT.TTSYukkuri.Config
 
                 if (!ServiceControl2.IsHostStarted)
                 {
-                    this.Logger.Info($"CeVIO RPC close.");
+                    this.AppLogger.Info($"CeVIO RPC close.");
                 }
             }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/SasaraConfig.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/SasaraConfig.cs
@@ -24,7 +24,7 @@ namespace ACT.TTSYukkuri.Config
     {
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -342,11 +342,11 @@ namespace ACT.TTSYukkuri.Config
             switch (result)
             {
                 case HostStartResult.Succeeded:
-                    this.Logger.Info($"CeVIO RPC start.");
+                    this.AppLogger.Info($"CeVIO RPC start.");
                     break;
 
                 case HostStartResult.AlreadyStarted:
-                    this.Logger.Info($"CeVIO RPC already started, connect to CeVIO.");
+                    this.AppLogger.Info($"CeVIO RPC already started, connect to CeVIO.");
                     break;
 
                 case HostStartResult.NotRegistered:
@@ -438,7 +438,7 @@ namespace ACT.TTSYukkuri.Config
 
                 if (!ServiceControl.IsHostStarted)
                 {
-                    this.Logger.Info($"CeVIO RPC close.");
+                    this.AppLogger.Info($"CeVIO RPC close.");
                 }
             }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Settings.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Settings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
+using System.Windows;
 using System.Xml.Serialization;
 using ACT.TTSYukkuri.Boyomichan;
 using ACT.TTSYukkuri.Discord.Models;
@@ -609,12 +610,39 @@ namespace ACT.TTSYukkuri.Config
 
                     if (File.Exists(file))
                     {
-                        using (var sr = new StreamReader(file, new UTF8Encoding(false)))
+                        try
                         {
-                            var xs = new XmlSerializer(typeof(Settings));
-                            instance = (Settings)xs.Deserialize(sr);
+                            using (var sr = new StreamReader(file, new UTF8Encoding(false)))
+                            {
+                                var xs = new XmlSerializer(typeof(Settings));
+                                instance = (Settings)xs.Deserialize(sr);
 
-                            activeConfig = instance;
+                                activeConfig = instance;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            var info = ex.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                            info += ex.Message + Environment.NewLine;
+                            info += ex.StackTrace.ToString();
+
+                            if (ex.InnerException != null)
+                            {
+                                info += Environment.NewLine + Environment.NewLine;
+                                info += "Inner Exception :" + Environment.NewLine;
+                                info += ex.InnerException.GetType().ToString() + Environment.NewLine + Environment.NewLine;
+                                info += ex.InnerException.Message + Environment.NewLine;
+                                info += ex.InnerException.StackTrace.ToString();
+                            }
+
+                            var result = MessageBox.Show("faild config load\n\n" + file + "\n" + info + "\n\ntry to load backup?", "error!", MessageBoxButton.YesNo);
+                            if (result == MessageBoxResult.Yes)
+                            {
+                                if (EnvironmentHelper.RestoreFile(file))
+                                {
+                                    Load();
+                                }
+                            }
                         }
                     }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GeneralViewModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/ViewModels/GeneralViewModel.cs
@@ -18,7 +18,7 @@ namespace ACT.TTSYukkuri.Config.ViewModels
     {
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -128,7 +128,7 @@ namespace ACT.TTSYukkuri.Config.ViewModels
         private void ExecuteClearBufferCommand()
         {
             BufferedWavePlayer.Instance?.ClearBuffers();
-            this.Logger.Info("Playback buffers cleared.");
+            this.AppLogger.Info("Playback buffers cleared.");
         }
 
         private DelegateCommand resetWasapiDeviceCommand;
@@ -142,7 +142,7 @@ namespace ACT.TTSYukkuri.Config.ViewModels
             await Task.Delay(10);
             SoundPlayerWrapper.LoadTTSCache();
 
-            this.Logger.Info("Reset WASAPI Player, and Reload TTS chache.");
+            this.AppLogger.Info("Reset WASAPI Player, and Reload TTS chache.");
         }
     }
 }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Config/Views/GeneralView.xaml.cs
@@ -20,7 +20,7 @@ namespace ACT.TTSYukkuri.Config.Views
     {
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -194,7 +194,7 @@ namespace ACT.TTSYukkuri.Config.Views
             Exception ex = null,
             bool modal = true)
         {
-            this.Logger.Error(ex, message);
+            this.AppLogger.Error(ex, message);
 
             var prompt = message;
             if (ex != null)

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Discord/Models/DiscordNetModel.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/Discord/Models/DiscordNetModel.cs
@@ -38,7 +38,7 @@ namespace ACT.TTSYukkuri.Discord.Models
 
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         private readonly StringBuilder log = new StringBuilder();
 
@@ -63,11 +63,11 @@ namespace ACT.TTSYukkuri.Discord.Models
             var log = $"[DISCORD] {message}";
             if (ex == null && !err)
             {
-                this.Logger.Trace(log);
+                this.AppLogger.Trace(log);
             }
             else
             {
-                this.Logger.Error(ex, log);
+                this.AppLogger.Error(ex, log);
             }
         }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/FFXIVWatcher.PartyWatcher.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/FFXIVWatcher.PartyWatcher.cs
@@ -190,10 +190,10 @@ namespace ACT.TTSYukkuri
                         if (hpp <= (decimal)config.HPThreshold &&
                             previousePartyMember.HPRate > (decimal)config.HPThreshold)
                         {
-                            if ((DateTime.Now - this.lastHPNotice).TotalSeconds >= NoticeInterval)
+                            if ((DateTime.UtcNow - this.lastHPNotice).TotalSeconds >= NoticeInterval)
                             {
                                 this.Speak(hpTextToSpeak, config.NoticeDeviceForHP, config.NoticeVoicePaletteForHP);
-                                this.lastHPNotice = DateTime.Now;
+                                this.lastHPNotice = DateTime.UtcNow;
                             }
                         }
                         else
@@ -201,7 +201,7 @@ namespace ACT.TTSYukkuri
                             if (hpp <= decimal.Zero && previousePartyMember.HPRate != decimal.Zero)
                             {
                                 this.SpeakEmpty("HP", deadman, config.NoticeDeviceForHP, config.NoticeVoicePaletteForHP);
-                                this.lastHPNotice = DateTime.Now;
+                                this.lastHPNotice = DateTime.UtcNow;
                             }
                         }
                     }
@@ -218,10 +218,10 @@ namespace ACT.TTSYukkuri
                             if (mpp <= (decimal)config.MPThreshold &&
                                 previousePartyMember.MPRate > (decimal)config.MPThreshold)
                             {
-                                if ((DateTime.Now - this.lastMPNotice).TotalSeconds >= NoticeInterval)
+                                if ((DateTime.UtcNow - this.lastMPNotice).TotalSeconds >= NoticeInterval)
                                 {
                                     this.Speak(mpTextToSpeak, config.NoticeDeviceForMP, config.NoticeVoicePaletteForMP);
-                                    this.lastMPNotice = DateTime.Now;
+                                    this.lastMPNotice = DateTime.UtcNow;
                                 }
                             }
                             else
@@ -229,7 +229,7 @@ namespace ACT.TTSYukkuri
                                 if (mpp <= decimal.Zero && previousePartyMember.MPRate != decimal.Zero)
                                 {
                                     this.SpeakEmpty("MP", deadman, config.NoticeDeviceForMP, config.NoticeVoicePaletteForMP);
-                                    this.lastMPNotice = DateTime.Now;
+                                    this.lastMPNotice = DateTime.UtcNow;
                                 }
                             }
                         }
@@ -247,10 +247,10 @@ namespace ACT.TTSYukkuri
                             if (tpp <= (decimal)config.TPThreshold &&
                                 previousePartyMember.TPRate > (decimal)config.TPThreshold)
                             {
-                                if ((DateTime.Now - this.lastTPNotice).TotalSeconds >= NoticeInterval)
+                                if ((DateTime.UtcNow - this.lastTPNotice).TotalSeconds >= NoticeInterval)
                                 {
                                     this.Speak(tpTextToSpeak, config.NoticeDeviceForTP, config.NoticeVoicePaletteForTP);
-                                    this.lastTPNotice = DateTime.Now;
+                                    this.lastTPNotice = DateTime.UtcNow;
                                 }
                             }
                             else
@@ -258,7 +258,7 @@ namespace ACT.TTSYukkuri
                                 if (tpp <= decimal.Zero && previousePartyMember.TPRate != decimal.Zero)
                                 {
                                     this.SpeakEmpty("TP", deadman, config.NoticeDeviceForTP, config.NoticeVoicePaletteForTP);
-                                    this.lastTPNotice = DateTime.Now;
+                                    this.lastTPNotice = DateTime.UtcNow;
                                 }
                             }
                         }
@@ -277,10 +277,10 @@ namespace ACT.TTSYukkuri
                             if (gpp >= (decimal)config.GPThreshold &&
                                 previousePartyMember.GPRate < (decimal)config.GPThreshold)
                             {
-                                if ((DateTime.Now - this.lastGPNotice).TotalSeconds >= NoticeInterval)
+                                if ((DateTime.UtcNow - this.lastGPNotice).TotalSeconds >= NoticeInterval)
                                 {
                                     this.Speak(gpTextToSpeak, config.NoticeDeviceForGP, config.NoticeVoicePaletteForGP);
-                                    this.lastGPNotice = DateTime.Now;
+                                    this.lastGPNotice = DateTime.UtcNow;
                                 }
                             }
                             else
@@ -288,7 +288,7 @@ namespace ACT.TTSYukkuri
                                 if (gpp >= 100m && previousePartyMember.GPRate < 100m)
                                 {
                                     this.SpeakEmpty("GP", deadman, config.NoticeDeviceForGP, config.NoticeVoicePaletteForGP);
-                                    this.lastGPNotice = DateTime.Now;
+                                    this.lastGPNotice = DateTime.UtcNow;
                                 }
                             }
                         }

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/KanjiTranslator.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/KanjiTranslator.cs
@@ -12,7 +12,7 @@ namespace ACT.TTSYukkuri
     {
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -69,24 +69,24 @@ namespace ACT.TTSYukkuri
 
                         if (this.IFELang == null)
                         {
-                            this.Logger.Warn("IFELANG IME initialize failed. Disabled IME reverse translation.");
+                            this.AppLogger.Warn("IFELANG IME initialize failed. Disabled IME reverse translation.");
                         }
                         else
                         {
                             var hr = this.IFELang.Open();
                             if (hr != 0)
                             {
-                                this.Logger.Warn("IFELANG IME connection failed. Disabled IME reverse translation.");
+                                this.AppLogger.Warn("IFELANG IME connection failed. Disabled IME reverse translation.");
                                 this.IFELang = null;
                             }
 
-                            this.Logger.Trace("IFELANG IME Connected.");
+                            this.AppLogger.Trace("IFELANG IME Connected.");
                         }
                     }
                 }
                 catch (Exception)
                 {
-                    this.Logger.Warn("IFELANG IME initialize failed due to an unexpected exception. Disabled IME reverse translation.");
+                    this.AppLogger.Warn("IFELANG IME initialize failed due to an unexpected exception. Disabled IME reverse translation.");
                     this.IFELang = null;
                 }
             }
@@ -112,7 +112,7 @@ namespace ACT.TTSYukkuri
                 var hr = ifelang.GetPhonetic(text, 1, -1, out t);
                 if (hr != 0)
                 {
-                    this.Logger.Error($"IFELANG IME translate to phonetic faild. text={text}");
+                    this.AppLogger.Error($"IFELANG IME translate to phonetic faild. text={text}");
                     return yomigana;
                 }
 
@@ -123,7 +123,7 @@ namespace ACT.TTSYukkuri
                 if (!this.hasWarned)
                 {
                     this.hasWarned = true;
-                    this.Logger.Warn($"IFELANG IME has been disabled. text={text}");
+                    this.AppLogger.Warn($"IFELANG IME has been disabled. text={text}");
                 }
             }
 

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/PluginCore.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/PluginCore.cs
@@ -47,7 +47,7 @@ namespace ACT.TTSYukkuri
 
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -320,7 +320,7 @@ namespace ACT.TTSYukkuri
             }
             catch (Exception ex)
             {
-                this.Logger.Error(ex, "SpeakTTS で例外が発生しました。");
+                this.AppLogger.Error(ex, "SpeakTTS で例外が発生しました。");
             }
         }
 
@@ -346,7 +346,7 @@ namespace ACT.TTSYukkuri
             WPFHelper.Start();
 
             AppLog.LoadConfiguration(AppLog.HojoringConfig);
-            this.Logger?.Trace(Assembly.GetExecutingAssembly().GetName().ToString() + " start.");
+            this.AppLogger?.Trace(Assembly.GetExecutingAssembly().GetName().ToString() + " start.");
 
             try
             {
@@ -369,7 +369,7 @@ namespace ACT.TTSYukkuri
                     this.DeInitPlugin();
                 });
 
-                this.Logger.Trace("[YUKKURI] Start InitPlugin");
+                this.AppLogger.Trace("[YUKKURI] Start InitPlugin");
 
                 var pluginInfo = ActGlobals.oFormActMain.PluginGetSelfData(plugin);
                 if (pluginInfo != null)
@@ -412,22 +412,16 @@ namespace ACT.TTSYukkuri
                 KanjiTranslator.Default.Initialize();
 
                 // TTSキャッシュの移行とGarbageを行う
-                await Task.Run(() =>
-                {
-                    this.MigrateTTSCache();
-                    this.GarbageTTSCache();
-                });
+                this.MigrateTTSCache();
+                this.GarbageTTSCache();
 
                 await EnvironmentHelper.WaitInitActDoneAsync();
 
-                await Task.Run(() =>
-                {
-                    // TTSを初期化する
-                    SpeechController.Default.Initialize();
+                // TTSを初期化する
+                SpeechController.Default.Initialize();
 
-                    // FF14監視スレッドを初期化する
-                    FFXIVWatcher.Initialize();
-                });
+                // FF14監視スレッドを初期化する
+                FFXIVWatcher.Initialize();
 
                 // 設定Panelを追加する
                 pluginScreenSpace.Controls.Add(new ElementHost()
@@ -439,7 +433,7 @@ namespace ACT.TTSYukkuri
                 // TTSメソッドを置き換える
                 this.StartReplaceTTSMethodTimer();
 
-                this.Logger.Trace("[YUKKURI] START Discord BOT INIT");
+                this.AppLogger.Trace("[YUKKURI] START Discord BOT INIT");
                 // DISCORD BOT クライアントを初期化する
                 DiscordClientModel.Model.Initialize();
                 // AutoJoinがONならば接続する
@@ -447,30 +441,13 @@ namespace ACT.TTSYukkuri
                 {
                     DiscordClientModel.Model.Connect(true);
                 }
-                this.Logger.Trace("[YUKKURI] END Discord BOT INIT");
-/*
-                await Task.Run(() =>
-                {
-                    this.Logger.Trace("[YUKKURI] START Discord BOT INIT");
-                    // DISCORD BOT クライアントを初期化する
-                    DiscordClientModel.Model.Initialize();
+                this.AppLogger.Trace("[YUKKURI] END Discord BOT INIT");
 
-                    // AutoJoinがONならば接続する
-                    if (Settings.Default.DiscordSettings.AutoJoin)
-                    {
-                        DiscordClientModel.Model.Connect(true);
-                    }
-                    this.Logger.Trace("[YUKKURI] END Discord BOT INIT");
-                });
-*/
-                await Task.Run(() =>
+                // VOICEROIDを起動する
+                if (SpeechController.Default is VoiceroidSpeechController ctrl)
                 {
-                    // VOICEROIDを起動する
-                    if (SpeechController.Default is VoiceroidSpeechController ctrl)
-                    {
-                        ctrl.Start();
-                    }
-                });
+                    ctrl.Start();
+                }
 
                 // Bridgeにメソッドを登録する
                 PlayBridge.Instance.SetBothDelegate((message, voicePalette, isSync, volume) => this.Speak(message, PlayDevices.Both, voicePalette, isSync, volume));
@@ -508,7 +485,7 @@ namespace ACT.TTSYukkuri
                     this.PluginStatusLabel.Text = "Plugin Started";
                 }
 
-                this.Logger.Trace("[YUKKURI] End InitPlugin");
+                this.AppLogger.Trace("[YUKKURI] End InitPlugin");
 
                 // 共通ビューを追加する
                 CommonViewHelper.Instance.AddCommonView(
@@ -521,7 +498,7 @@ namespace ACT.TTSYukkuri
             }
             catch (Exception ex)
             {
-                this.Logger.Error(ex, "InitPlugin error.");
+                this.AppLogger.Error(ex, "InitPlugin error.");
 
                 ModernMessageBox.ShowDialog(
                     "Plugin init error !",
@@ -611,7 +588,7 @@ namespace ACT.TTSYukkuri
             }
             catch (Exception ex)
             {
-                this.Logger.Error(ex, "DeInitPlugin error.");
+                this.AppLogger.Error(ex, "DeInitPlugin error.");
             }
         }
 
@@ -639,7 +616,7 @@ namespace ACT.TTSYukkuri
             (string logLine, Match match) =>
             {
                 BufferedWavePlayer.Instance?.ClearBuffers();
-                this.Logger.Info("Playback buffers cleared.");
+                this.AppLogger.Info("Playback buffers cleared.");
             })
             {
                 IsSilent = true,
@@ -728,7 +705,7 @@ namespace ACT.TTSYukkuri
                     Assembly.GetExecutingAssembly());
                 if (!string.IsNullOrWhiteSpace(message))
                 {
-                    this.Logger.Error(message);
+                    this.AppLogger.Error(message);
                 }
 
                 Settings.Default.LastUpdateDateTime = DateTime.Now;

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SoundPlayerWrapper.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/SoundPlayerWrapper.cs
@@ -23,7 +23,7 @@ namespace ACT.TTSYukkuri
     {
         #region Logger
 
-        private static NLog.Logger Logger => AppLog.DefaultLogger;
+        private static NLog.Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -72,7 +72,7 @@ namespace ACT.TTSYukkuri
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "Playback stream initialize faild. Play mute.wav.");
+                AppLogger.Error(ex, "Playback stream initialize faild. Play mute.wav.");
             }
         }
 
@@ -184,7 +184,7 @@ namespace ACT.TTSYukkuri
                 isSync);
         }
 
-        private static readonly Random Random = new Random((int)DateTime.Now.Ticks);
+        //private static readonly Random Random = new Random((int)DateTime.Now.Ticks);
 
         public static void LoadTTSCache()
         {
@@ -204,13 +204,17 @@ namespace ACT.TTSYukkuri
 
                 try
                 {
-                    Logger.Info("Started loading TTS caches.");
+                    AppLogger.Info("Started loading TTS caches.");
                     BufferedWavePlayer.PlayerSet.LoadTTSHistory();
                     count = BufferedWavePlayer.Instance.BufferWaves(volume);
                 }
+                catch(Exception ex)
+                {
+                    AppLogger.Error(ex, "check cache folder or clear cache.");
+                }
                 finally
                 {
-                    Logger.Info($"Completed loading TTS caches. {count} files has loaded.");
+                    AppLogger.Info($"Completed loading TTS caches. {count} files has loaded.");
                 }
             }));
         }

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Common/TTSDictionary.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Common/TTSDictionary.cs
@@ -24,7 +24,7 @@ namespace ACT.UltraScouter.Common
 
         #region Logger
 
-        private Logger logger = AppLog.DefaultLogger;
+        private Logger AppLogger = AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -97,7 +97,7 @@ namespace ACT.UltraScouter.Common
                 }
             }
 
-            this.logger.Info($"TTSDictionary loaded. {this.SourceFile}");
+            this.AppLogger.Info($"TTSDictionary loaded. {this.SourceFile}");
         }
     }
 }

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/MobList.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/MobList.cs
@@ -43,7 +43,7 @@ namespace ACT.UltraScouter.Config
     {
         #region Logger
 
-        private Logger logger = AppLog.DefaultLogger;
+        private Logger AppLogger = AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -401,7 +401,7 @@ namespace ACT.UltraScouter.Config
                 }
             }
 
-            this.logger.Info($"MobList loaded. {this.MobListFile}");
+            this.AppLogger.Info($"MobList loaded. {this.MobListFile}");
         }
 
         #endregion Target MobList

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/ViewModels/CombatantsViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/ViewModels/CombatantsViewModel.cs
@@ -67,12 +67,12 @@ namespace ACT.UltraScouter.Config.UI.ViewModels
                 return;
             }
 
-            if ((DateTime.Now - lastUpdateDatetime).TotalSeconds <= 3.0d)
+            if ((DateTime.UtcNow - lastUpdateDatetime).TotalSeconds <= 3.0d)
             {
                 return;
             }
 
-            lastUpdateDatetime = DateTime.Now;
+            lastUpdateDatetime = DateTime.UtcNow;
 
             var combatants = Combatants;
 

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/ViewModels/MobListConfigViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Config/UI/ViewModels/MobListConfigViewModel.cs
@@ -17,7 +17,7 @@ namespace ACT.UltraScouter.Config.UI.ViewModels
     {
         #region Logger
 
-        private Logger logger = AppLog.DefaultLogger;
+        private Logger AppLogger = AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -53,7 +53,7 @@ namespace ACT.UltraScouter.Config.UI.ViewModels
 
                 if (!File.Exists(f))
                 {
-                    this.logger.Error($"TargetMobList not found. {f}");
+                    this.AppLogger.Error($"TargetMobList not found. {f}");
                     return;
                 }
 
@@ -69,7 +69,7 @@ namespace ACT.UltraScouter.Config.UI.ViewModels
 
                 if (!File.Exists(f))
                 {
-                    this.logger.Error($"TargetMobList not found. {f}");
+                    this.AppLogger.Error($"TargetMobList not found. {f}");
                     return;
                 }
 

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/EnemyHPListModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/EnemyHPListModel.cs
@@ -167,7 +167,7 @@ namespace ACT.UltraScouter.Models
             var liquid = DesignModeEnemyList[0];
             var hand = DesignModeEnemyList[1];
 
-            var rate = (double)(60 - DateTime.Now.Second) / 60d;
+            var rate = (double)(60 - DateTime.UtcNow.Second) / 60d;
 
             liquid.CurrentHP = (uint)(liquid.MaxHP * rate);
             hand.CurrentHP = (uint)(hand.MaxHP * (rate * 0.9d));

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/FFLogs/ParseTotalModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/FFLogs/ParseTotalModel.cs
@@ -25,7 +25,7 @@ namespace ACT.UltraScouter.Models.FFLogs
     {
         #region Logger
 
-        private static Logger Logger => AppLog.DefaultLogger;
+        private static Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -406,7 +406,7 @@ namespace ACT.UltraScouter.Models.FFLogs
 
         private const int CheckLimit = 2500;
         private const int CheckInterval = 250;
-        private static readonly Random Random = new Random(DateTime.Now.Second);
+        private static readonly Random Random = new Random(DateTime.UtcNow.Second);
         private FFLogsPartitions previousPartition = FFLogsPartitions.Current;
 
         private static readonly string ServerPrefixKR = "Kr";
@@ -557,7 +557,7 @@ namespace ACT.UltraScouter.Models.FFLogs
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error(
+                    AppLogger.Error(
                         ex,
                         $"Error FFLogs API. charactername={characterName} server={server} region={region} uri={uri}");
 

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/FFLogs/StatisticsDatabase.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/FFLogs/StatisticsDatabase.cs
@@ -33,7 +33,7 @@ namespace ACT.UltraScouter.Models.FFLogs
 
         public string APIKey { get; set; }
 
-        public Logger Logger { get; set; }
+        public Logger AppLogger { get; set; }
 
         private ZonesModel[] zones;
         private ClassesModel classes;
@@ -433,7 +433,7 @@ namespace ACT.UltraScouter.Models.FFLogs
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, "[FFLogs] error downloding statistics database.");
+                AppLogger.Error(ex, "[FFLogs] error downloding statistics database.");
             }
             finally
             {
@@ -623,12 +623,12 @@ namespace ACT.UltraScouter.Models.FFLogs
         {
             if (ex == null)
             {
-                this.Logger?.Trace(message);
+                this.AppLogger?.Trace(message);
                 Console.WriteLine(message);
             }
             else
             {
-                this.Logger?.Error(ex, message);
+                this.AppLogger?.Error(ex, message);
                 Console.WriteLine(message);
                 Console.WriteLine(ex);
             }
@@ -640,12 +640,12 @@ namespace ACT.UltraScouter.Models.FFLogs
         {
             if (ex == null)
             {
-                this.Logger?.Error(ex, message);
+                this.AppLogger?.Error(ex, message);
                 Console.WriteLine(message);
             }
             else
             {
-                this.Logger?.Error(ex, message);
+                this.AppLogger?.Error(ex, message);
                 Console.WriteLine(message);
                 Console.WriteLine(ex);
             }

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/MobInfo.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/MobInfo.cs
@@ -426,7 +426,7 @@ namespace ACT.UltraScouter.Models
                 return;
             }
 
-            if ((DateTime.Now - MobInfo.beforeTTSTimestamp).TotalSeconds >= 3.0)
+            if ((DateTime.UtcNow - MobInfo.beforeTTSTimestamp).TotalSeconds >= 3.0)
             {
                 MobInfo.beforeTTS = string.Empty;
             }
@@ -444,7 +444,7 @@ namespace ACT.UltraScouter.Models
                 }
 
                 MobInfo.beforeTTS = tts;
-                MobInfo.beforeTTSTimestamp = DateTime.Now;
+                MobInfo.beforeTTSTimestamp = DateTime.UtcNow;
             }
         }
 

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/MyStatusModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/MyStatusModel.cs
@@ -100,7 +100,7 @@ namespace ACT.UltraScouter.Models
         {
             this.MaxHP = DummyMaxHP;
 
-            var rate = (double)(((DateTime.Now.Second % 10) + 1)) / 10d;
+            var rate = (double)(((DateTime.UtcNow.Second % 10) + 1)) / 10d;
 
             var currentHP = (uint)(DummyMaxHP * rate);
             var currentMP = (uint)(this.MaxMP * rate);

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/TargetInfoModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/TargetInfoModel.cs
@@ -655,12 +655,13 @@ namespace ACT.UltraScouter.Models
                 return;
             }
 
+            var now = DateTime.Now;
             var ttl = Settings.Instance.FFLogs.RefreshInterval * 1.5d * -1;
 
             lock (ParseTotalDictionary)
             {
                 var targets = ParseTotalDictionary
-                    .Where(x => x.Value.Timestamp < DateTime.Now.AddMinutes(ttl))
+                    .Where(x => x.Value.Timestamp < now.AddMinutes(ttl))
                     .ToArray();
 
                 foreach (var item in targets)
@@ -669,7 +670,7 @@ namespace ACT.UltraScouter.Models
                 }
             }
 
-            this.lastGarbageTimestamp = DateTime.Now;
+            this.lastGarbageTimestamp = now;
         }
 
         private static System.Timers.Timer textCommandTTLTimer;

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/TickerModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Models/TickerModel.cs
@@ -168,7 +168,7 @@ namespace ACT.UltraScouter.Models
                 return;
             }
 
-            if ((DateTime.Now - this.lastSyncTimestamp).TotalSeconds <= config.ResyncInterval)
+            if ((DateTime.UtcNow - this.lastSyncTimestamp).TotalSeconds <= config.ResyncInterval)
             {
                 return;
             }
@@ -189,7 +189,7 @@ namespace ACT.UltraScouter.Models
             if (mpDiff == HealerInCombatMPRecoverValue ||
                 StandardMPRecoveryValues.Contains(mpDiff))
             {
-                this.lastSyncTimestamp = DateTime.Now;
+                this.lastSyncTimestamp = DateTime.UtcNow;
                 this.RestartTickerCallback?.Invoke();
                 this.AppLogger.Trace($"3s ticker synced to MP. diff={mpDiff}");
             }
@@ -240,7 +240,7 @@ namespace ACT.UltraScouter.Models
 
                 var config = Settings.Instance.MPTicker;
 
-                if ((DateTime.Now - this.lastSyncTimestamp).TotalSeconds <= config.ResyncInterval)
+                if ((DateTime.UtcNow - this.lastSyncTimestamp).TotalSeconds <= config.ResyncInterval)
                 {
                     return;
                 }
@@ -314,7 +314,7 @@ namespace ACT.UltraScouter.Models
                 return;
             }
 
-            this.lastSyncTimestamp = DateTime.Now;
+            this.lastSyncTimestamp = DateTime.UtcNow;
 
             Task.Run(() =>
             {

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/PluginCore.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/PluginCore.cs
@@ -46,7 +46,7 @@ namespace ACT.UltraScouter
 
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -71,7 +71,7 @@ namespace ACT.UltraScouter
 
             try
             {
-                this.Logger.Trace("start DeInitPlugin");
+                this.AppLogger.Trace("start DeInitPlugin");
 
                 // 設定ファイルを保存する
                 Settings.Instance.Save();
@@ -95,11 +95,11 @@ namespace ACT.UltraScouter
                     this.PluginStatusLabel.Text = "Plugin exited.";
                 }
 
-                this.Logger.Trace("end DeInitPlugin. succeeded.");
+                this.AppLogger.Trace("end DeInitPlugin. succeeded.");
             }
             catch (Exception ex)
             {
-                this.Logger.Fatal(ex, "DeInitPlugin error.");
+                this.AppLogger.Fatal(ex, "DeInitPlugin error.");
                 this.ShowMessage("DeInitPlugin error.", ex);
             }
             finally
@@ -124,7 +124,7 @@ namespace ACT.UltraScouter
             WPFHelper.Start();
 
             AppLog.LoadConfiguration(AppLog.HojoringConfig);
-            this.Logger?.Trace(Assembly.GetExecutingAssembly().GetName().ToString() + " start.");
+            this.AppLogger?.Trace(Assembly.GetExecutingAssembly().GetName().ToString() + " start.");
 
             try
             {
@@ -148,7 +148,7 @@ namespace ACT.UltraScouter
                     this.EndPlugin();
                 });
 
-                this.Logger.Trace("[ULTRA SCOUTER] Start InitPlugin");
+                this.AppLogger.Trace("[ULTRA SCOUTER] Start InitPlugin");
 
                 // .NET FrameworkとOSのバージョンを確認する
                 if (!UpdateChecker.IsAvailableDotNet() ||
@@ -182,21 +182,15 @@ namespace ACT.UltraScouter
                     Settings.Instance.FileName);
 
                 // 各種ファイルを読み込む
-                await Task.Run(() =>
-                {
-                    TTSDictionary.Instance.Load();
-                    Settings.Instance.MobList.LoadTargetMobList();
-                });
+                TTSDictionary.Instance.Load();
+                Settings.Instance.MobList.LoadTargetMobList();
 
                 await EnvironmentHelper.WaitInitActDoneAsync();
 
                 // FFXIVプラグインへのアクセスを開始する
-                await Task.Run(() =>
-                {
-                    XIVPluginHelper.Instance.Start(
-                        Settings.Instance.PollingRate,
-                        Settings.Instance.FFXIVLocale);
-                });
+                XIVPluginHelper.Instance.Start(
+                    Settings.Instance.PollingRate,
+                    Settings.Instance.FFXIVLocale);
 
                 // ターゲット情報ワーカを開始する
                 MainWorker.Instance.Start();
@@ -212,7 +206,7 @@ namespace ACT.UltraScouter
                     this.PluginStatusLabel.Text = "Plugin started.";
                 }
 
-                this.Logger.Trace("[ULTRA SCOUTER] End InitPlugin");
+                this.AppLogger.Trace("[ULTRA SCOUTER] End InitPlugin");
 
                 // 共通ビューを追加する
                 CommonViewHelper.Instance.AddCommonView(
@@ -221,7 +215,7 @@ namespace ACT.UltraScouter
                 this.isLoaded = true;
 
                 // FFLogsの統計データベースをロードする
-                StatisticsDatabase.Instance.Logger = Logger;
+                StatisticsDatabase.Instance.AppLogger = AppLogger;
                 await StatisticsDatabase.Instance.LoadAsync();
 
                 // アップデートを確認する
@@ -229,7 +223,7 @@ namespace ACT.UltraScouter
             }
             catch (Exception ex)
             {
-                this.Logger.Fatal(ex, "InitPlugin error.");
+                this.AppLogger.Fatal(ex, "InitPlugin error.");
                 this.ShowMessage("InitPlugin error.", ex);
             }
         }
@@ -289,7 +283,7 @@ namespace ACT.UltraScouter
                     Assembly.GetExecutingAssembly());
                 if (!string.IsNullOrWhiteSpace(message))
                 {
-                    this.Logger.Fatal(message);
+                    this.AppLogger.Fatal(message);
                 }
 
                 Settings.Instance.LastUpdateDateTime = DateTime.Now;

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/ActionViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/ActionViewModel.cs
@@ -23,7 +23,7 @@ namespace ACT.UltraScouter.ViewModels
     {
         #region Logger
 
-        private Logger logger = AppLog.DefaultLogger;
+        private Logger AppLogger = AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -182,7 +182,7 @@ namespace ACT.UltraScouter.ViewModels
 
             var message =
                 $"{args.Actor} starts using {args.CastSkillName}. duration={args.CastDurationMax}, id={args.CastSkillID}";
-            this.logger.Info(message);
+            this.AppLogger.Info(message);
         }
 
         private void CountdownTimer_Tick(

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/HPBarViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/HPBarViewModel.cs
@@ -146,12 +146,12 @@ namespace ACT.UltraScouter.ViewModels
                 this.Config.ProgressBar.OutlineColor;
 
             // HPバーの進捗率を更新する
-            if ((DateTime.Now - this.lastHPBarUpdateDateTime).TotalSeconds >= 0.1d)
+            if ((DateTime.UtcNow - this.lastHPBarUpdateDateTime).TotalSeconds >= 0.1d)
             {
                 var view = this.View as HPBarView;
                 if (view != null)
                 {
-                    this.lastHPBarUpdateDateTime = DateTime.Now;
+                    this.lastHPBarUpdateDateTime = DateTime.UtcNow;
 
                     // HPバーを描画する
                     view.UpdateHPBar(this.Model.CurrentHPRate);

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/MPTickerViewModel.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/ViewModels/MPTickerViewModel.cs
@@ -110,10 +110,10 @@ namespace ACT.UltraScouter.ViewModels
                     if (this.previousCombatStat != inCombat)
                     {
                         this.previousCombatStat = inCombat;
-                        this.endCombatTimestamp = DateTime.Now;
+                        this.endCombatTimestamp = DateTime.UtcNow;
                     }
 
-                    if ((DateTime.Now - this.endCombatTimestamp).TotalSeconds >=
+                    if ((DateTime.UtcNow - this.endCombatTimestamp).TotalSeconds >=
                         this.Config.ExplationTimeForDisplay)
                     {
                         return false;

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MainWorker.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MainWorker.cs
@@ -61,7 +61,7 @@ namespace ACT.UltraScouter.Workers
 
         #region Logger
 
-        private Logger logger = AppLog.DefaultLogger;
+        private Logger AppLogger = AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -182,7 +182,7 @@ namespace ACT.UltraScouter.Workers
                     }
                     catch (Exception ex)
                     {
-                        this.logger.Fatal(ex, "GetOverlayData error.");
+                        this.AppLogger.Fatal(ex, "GetOverlayData error.");
                     }
                 },
                 Settings.Instance.PollingRate,

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MobListWorker.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/MobListWorker.cs
@@ -59,7 +59,7 @@ namespace ACT.UltraScouter.Workers
         {
             lock (this.TargetInfoLock)
             {
-                var now = DateTime.Now;
+                var now = DateTime.UtcNow;
                 if ((now - this.combatantsTimestamp).TotalMilliseconds
                     < Settings.Instance.MobList.RefreshRateMin)
                 {

--- a/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/TargetInfoWorker.cs
+++ b/source/ACT.UltraScouter/ACT.UltraScouter.Core/Workers/TargetInfoWorker.cs
@@ -36,7 +36,7 @@ namespace ACT.UltraScouter.Workers
 
         #region Logger
 
-        private Logger logger = AppLog.DefaultLogger;
+        private Logger AppLogger = AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -302,7 +302,7 @@ namespace ACT.UltraScouter.Workers
             }
             catch (Exception ex)
             {
-                this.logger.Fatal(ex, "UpdateOverlayData error.");
+                this.AppLogger.Fatal(ex, "UpdateOverlayData error.");
             }
         }
 

--- a/source/ACT.XIVLog/VideoCapture.cs
+++ b/source/ACT.XIVLog/VideoCapture.cs
@@ -33,7 +33,7 @@ namespace ACT.XIVLog
 
         #region Logger
 
-        private Logger Logger => AppLog.DefaultLogger;
+        private Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -101,7 +101,7 @@ namespace ACT.XIVLog
                     ActGlobals.oFormActMain.CurrentZone;
 
                 if (Config.Instance.TryCountContentName != contentName ||
-                    (DateTime.Now - Config.Instance.TryCountTimestamp) >=
+                    (DateTime.UtcNow - Config.Instance.TryCountTimestamp) >=
                     TimeSpan.FromHours(Config.Instance.TryCountResetInterval))
                 {
                     this.TryCount = 0;
@@ -131,7 +131,7 @@ namespace ACT.XIVLog
                     this.contentName = ActGlobals.oFormActMain.CurrentZone;
 
                     if (Config.Instance.TryCountContentName != this.contentName ||
-                        (DateTime.Now - Config.Instance.TryCountTimestamp) >=
+                        (DateTime.UtcNow - Config.Instance.TryCountTimestamp) >=
                         TimeSpan.FromHours(Config.Instance.TryCountResetInterval))
                     {
                         this.TryCount = 0;
@@ -191,7 +191,7 @@ namespace ACT.XIVLog
             set => WPFHelper.Invoke(() =>
             {
                 Config.Instance.VideoTryCount = value;
-                Config.Instance.TryCountTimestamp = DateTime.Now;
+                Config.Instance.TryCountTimestamp = DateTime.UtcNow;
 
                 var contentName = !string.IsNullOrEmpty(this.contentName) ?
                     this.contentName :
@@ -229,13 +229,13 @@ namespace ACT.XIVLog
             {
                 if (!inCombat)
                 {
-                    this.endCombatDateTime = DateTime.Now;
+                    this.endCombatDateTime = DateTime.UtcNow;
                 }
             }
 
             if (!inCombat)
             {
-                if ((DateTime.Now - this.endCombatDateTime) >= TimeSpan.FromMinutes(min))
+                if ((DateTime.UtcNow - this.endCombatDateTime) >= TimeSpan.FromMinutes(min))
                 {
                     this.FinishRecording();
                 }
@@ -314,7 +314,7 @@ namespace ACT.XIVLog
                         this.StopRecordingSubscriber.Elapsed += (_, __) => this.DetectStopRecording();
                     }
 
-                    this.endCombatDateTime = DateTime.Now;
+                    this.endCombatDateTime = DateTime.UtcNow;
                     this.StopRecordingSubscriber.Start();
                 }
             }
@@ -470,7 +470,7 @@ namespace ACT.XIVLog
                 }
                 else
                 {
-                    this.Logger.Info("Tried to record, but OBS Websocket connect faild.");
+                    this.AppLogger.Info("Tried to record, but OBS Websocket connect faild.");
                 }
             }
             else
@@ -479,7 +479,7 @@ namespace ACT.XIVLog
                 if (p == null ||
                     p.Length < 1)
                 {
-                    this.Logger.Info("Tried to record, but Streamlabs OBS is not found.");
+                    this.AppLogger.Info("Tried to record, but Streamlabs OBS is not found.");
                     return;
                 }
 

--- a/source/ACT.XIVLog/XIVLogPlugin.cs
+++ b/source/ACT.XIVLog/XIVLogPlugin.cs
@@ -171,7 +171,7 @@ namespace ACT.XIVLog
 
                 if (LogQueue.IsEmpty)
                 {
-                    if ((DateTime.Now - this.lastWroteTimestamp).TotalSeconds > 10)
+                    if ((DateTime.UtcNow - this.lastWroteTimestamp).TotalSeconds > 10)
                     {
                         this.lastWroteTimestamp = DateTime.MaxValue;
                         isNeedsFlush = true;
@@ -186,7 +186,7 @@ namespace ACT.XIVLog
                     }
                 }
 
-                if ((DateTime.Now - this.lastFlushTimestamp).TotalSeconds
+                if ((DateTime.UtcNow - this.lastFlushTimestamp).TotalSeconds
                     >= config.FlushInterval)
                 {
                     isNeedsFlush = true;
@@ -243,7 +243,7 @@ namespace ACT.XIVLog
                     xivlog.Parse();
 
                     this.writter.WriteLine(xivlog.ToCSVLine());
-                    this.lastWroteTimestamp = DateTime.Now;
+                    this.lastWroteTimestamp = DateTime.UtcNow;
                     Thread.Yield();
                 }
 
@@ -253,7 +253,7 @@ namespace ACT.XIVLog
                     if (isNeedsFlush || this.isForceFlush)
                     {
                         this.isForceFlush = false;
-                        this.lastFlushTimestamp = DateTime.Now;
+                        this.lastFlushTimestamp = DateTime.UtcNow;
                         this.writter?.Flush();
                     }
                 }
@@ -581,9 +581,10 @@ namespace ACT.XIVLog
                 return;
             }
 
+            var now = DateTime.Now;
             // 古くなったエントリを削除する
             var olds = PCNameDictionary.Where(x =>
-                (DateTime.Now - x.Value.Timestamp).TotalMinutes >= 10.0)
+                (now - x.Value.Timestamp).TotalMinutes >= 10.0)
                 .ToArray();
             foreach (var toRemove in olds)
             {
@@ -595,7 +596,7 @@ namespace ACT.XIVLog
             {
                 var alias = new Alias(
                     $"{com.JobInfo?.NameEN.Replace(" ", string.Empty) ?? "Unknown"} {JobAliases[com.Job % 10]}",
-                    DateTime.Now);
+                    now);
                 PCNameDictionary[com.Name] = alias;
                 PCNameDictionary[com.NameFI] = alias;
                 PCNameDictionary[com.NameIF] = alias;

--- a/source/FFXIV.Framework/FFXIV.Framework/Common/CommonHelper.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Common/CommonHelper.cs
@@ -15,7 +15,7 @@ namespace FFXIV.Framework.Common
         public static bool IsDebugMode => false;
 #endif
 
-        private static readonly Random random = new Random((int)DateTime.Now.Ticks);
+        private static readonly Random random = new Random((int)DateTime.UtcNow.Ticks);
 
         public static Random Random => random;
 

--- a/source/FFXIV.Framework/FFXIV.Framework/Common/TaskWorker.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Common/TaskWorker.cs
@@ -9,7 +9,7 @@ namespace FFXIV.Framework.Common
     {
         #region Logger
 
-        private static Logger Logger => AppLog.DefaultLogger;
+        private static Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -74,13 +74,13 @@ namespace FFXIV.Framework.Common
             Thread.CurrentThread.IsBackground = true;
 
             Thread.Sleep((int)this.Interval);
-            Logger.Trace($"TaskWorker - {this.Name} start.");
+            AppLogger.Trace($"TaskWorker - {this.Name} start.");
 
             while (true)
             {
                 if (token.IsCancellationRequested)
                 {
-                    Logger.Trace($"TaskWorker - {this.Name} cancel.");
+                    AppLogger.Trace($"TaskWorker - {this.Name} cancel.");
                     return;
                 }
 
@@ -90,7 +90,7 @@ namespace FFXIV.Framework.Common
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error(ex, $"TaskWorker - {this.Name} error.");
+                    AppLogger.Error(ex, $"TaskWorker - {this.Name} error.");
                 }
 
                 Thread.Sleep((int)this.Interval);

--- a/source/FFXIV.Framework/FFXIV.Framework/Common/ThreadWorker.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Common/ThreadWorker.cs
@@ -8,7 +8,7 @@ namespace FFXIV.Framework.Common
     {
         #region Logger
 
-        private static Logger Logger => AppLog.DefaultLogger;
+        private static Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -80,7 +80,7 @@ namespace FFXIV.Framework.Common
 
             this.IsRunning = false;
 
-            Logger.Trace($"ThreadWorker - {this.Name} end.{(result ? " aborted" : string.Empty)}");
+            AppLogger.Trace($"ThreadWorker - {this.Name} end.{(result ? " aborted" : string.Empty)}");
 
             return result;
         }
@@ -100,7 +100,7 @@ namespace FFXIV.Framework.Common
         private void DoWorkLoop()
         {
             Thread.Sleep((int)this.Interval);
-            Logger.Trace($"ThreadWorker - {this.Name} start.");
+            AppLogger.Trace($"ThreadWorker - {this.Name} start.");
 
             while (!this.isAbort)
             {
@@ -111,12 +111,12 @@ namespace FFXIV.Framework.Common
                 catch (ThreadAbortException)
                 {
                     this.isAbort = true;
-                    Logger.Trace($"ThreadWorker - {this.Name} abort.");
+                    AppLogger.Trace($"ThreadWorker - {this.Name} abort.");
                     break;
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error(ex, $"ThreadWorker - {this.Name} error.");
+                    AppLogger.Error(ex, $"ThreadWorker - {this.Name} error.");
                 }
 
                 if (this.isAbort)

--- a/source/FFXIV.Framework/FFXIV.Framework/Common/TimerWorker.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Common/TimerWorker.cs
@@ -8,7 +8,7 @@ namespace FFXIV.Framework.Common
     {
         #region Logger
 
-        private static Logger Logger => AppLog.DefaultLogger;
+        private static Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -61,7 +61,7 @@ namespace FFXIV.Framework.Common
                 this.timer = null;
             }
 
-            Logger.Trace($"TimerWorker - {this.Name} end.");
+            AppLogger.Trace($"TimerWorker - {this.Name} end.");
         }
 
         public void Run()
@@ -73,7 +73,7 @@ namespace FFXIV.Framework.Common
             this.timer.Elapsed += this.Elapsed;
             this.timer.Start();
 
-            Logger.Trace($"TimerWorker - {this.Name} start.");
+            AppLogger.Trace($"TimerWorker - {this.Name} start.");
         }
 
         private void Elapsed(object sender, ElapsedEventArgs e)
@@ -88,7 +88,7 @@ namespace FFXIV.Framework.Common
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error(ex, $"TimerWorker - {this.Name} error.");
+                    AppLogger.Error(ex, $"TimerWorker - {this.Name} error.");
                 }
             }
         }

--- a/source/FFXIV.Framework/FFXIV.Framework/Common/UpdateChecker.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Common/UpdateChecker.cs
@@ -28,7 +28,7 @@ namespace FFXIV.Framework.Common
     {
         #region Logger
 
-        private static Logger Logger => AppLog.DefaultLogger;
+        private static Logger AppLogger => AppLog.DefaultLogger;
 
         #endregion Logger
 
@@ -131,7 +131,7 @@ namespace FFXIV.Framework.Common
             {
                 // エントリアセンブリのパスを出力する
                 var entry = Assembly.GetEntryAssembly().Location;
-                Logger.Trace($"Entry {entry}");
+                AppLogger.Trace($"Entry {entry}");
 
                 // ついでにFFXIV_ACT_Pluginのバージョンを出力する
                 var ffxivPlugin = ActGlobals.oFormActMain?.ActPlugins?
@@ -144,7 +144,7 @@ namespace FFXIV.Framework.Common
                     var vi = FileVersionInfo.GetVersionInfo(ffxivPlugin);
                     if (vi != null)
                     {
-                        Logger.Trace($"FFXIV_ACT_Plugin v{vi.FileMajorPart}.{vi.FileMinorPart}.{vi.FileBuildPart}.{vi.FilePrivatePart}");
+                        AppLogger.Trace($"FFXIV_ACT_Plugin v{vi.FileMajorPart}.{vi.FileMinorPart}.{vi.FileBuildPart}.{vi.FilePrivatePart}");
                     }
                 }
 
@@ -155,7 +155,7 @@ namespace FFXIV.Framework.Common
                     var ver = hojoring.Version as Version;
                     if (ver != null)
                     {
-                        Logger.Trace($"Hojoring v{ver.Major}.{ver.Minor}.{ver.Revision}");
+                        AppLogger.Trace($"Hojoring v{ver.Major}.{ver.Minor}.{ver.Revision}");
                     }
 
                     hojoring.ShowSplash("initializing...");
@@ -253,7 +253,7 @@ namespace FFXIV.Framework.Common
                     var match = ReleaseVersionTitleRegex.Match(lastestReleaseVersion);
                     if (!match.Success)
                     {
-                        Logger.Trace($"Update checker. Unknown release version.");
+                        AppLogger.Trace($"Update checker. Unknown release version.");
                         return r;
                     }
 
@@ -266,7 +266,7 @@ namespace FFXIV.Framework.Common
 
                     if (remoteVersion <= currentVersion)
                     {
-                        Logger.Trace($"Update checker. up to date.");
+                        AppLogger.Trace($"Update checker. up to date.");
                         return r;
                     }
                 }
@@ -379,7 +379,7 @@ namespace FFXIV.Framework.Common
                 var result = IsDotNet471();
                 lastResult = result;
 
-                Logger.Info(
+                AppLogger.Info(
                     result ?
                     $".NET Framework is Available." :
                     $".NET Framework is OLD.");
@@ -472,7 +472,7 @@ namespace FFXIV.Framework.Common
             }
             catch (Exception ex)
             {
-                Logger.Info($"faild get WMI, {ex}");
+                AppLogger.Info($"faild get WMI, {ex}");
                 buildNo = GetRegistryValue(
                 @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion",
                 "CurrentBuild");
@@ -511,8 +511,8 @@ namespace FFXIV.Framework.Common
                 osBuildNo = i;
             }
 
-            Logger.Info($"{productName} Version {DisplayVersion}, build {buildNo}");
-            Logger.Info($".NET Framework Version {dotNetVersion}, release {dotNetReleaseID}");
+            AppLogger.Info($"{productName} Version {DisplayVersion}, build {buildNo}");
+            AppLogger.Info($".NET Framework Version {dotNetVersion}, release {dotNetReleaseID}");
         }
 
         public static bool IsWindowsNewer =>
@@ -540,8 +540,8 @@ namespace FFXIV.Framework.Common
                     if (!shownWindowsIsOld)
                     {
                         shownWindowsIsOld = true;
-                        Logger.Warn($"{prompt1} {prompt2}");
-                        Logger.Warn($"Support Win7 manualy, but you'd better update to Windows 10. https://www.microsoft.com/software-download/windows10");
+                        AppLogger.Warn($"{prompt1} {prompt2}");
+                        AppLogger.Warn($"Support Win7 manualy, but you'd better update to Windows 10. https://www.microsoft.com/software-download/windows10");
                     }
                 }
                 else
@@ -549,7 +549,7 @@ namespace FFXIV.Framework.Common
                     if (!shownWindowsIsOld)
                     {
                         shownWindowsIsOld = true;
-                        Logger.Error($"{prompt1} {prompt2}");
+                        AppLogger.Error($"{prompt1} {prompt2}");
                         WPFHelper.BeginInvoke(
                             () => ModernMessageBox.ShowDialog(
                                 $"{prompt1}\n{prompt2}",

--- a/source/FFXIV.Framework/FFXIV.Framework/WPF/Views/OverlayExtensions.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/WPF/Views/OverlayExtensions.cs
@@ -354,7 +354,7 @@ namespace FFXIV.Framework.WPF.Views
                     }
 
                     // プロセス情報がなく、tryIntervalよりも時間が経っているときは新たに取得を試みる
-                    if (xivProc == null && (DateTime.Now - lastTry) > TryInterval)
+                    if (xivProc == null && (DateTime.UtcNow - lastTry) > TryInterval)
                     {
                         xivProc = XIVPluginHelper.Instance.CurrentFFXIVProcess;
 
@@ -368,7 +368,7 @@ namespace FFXIV.Framework.WPF.Views
                             }
                         }
 
-                        lastTry = DateTime.Now;
+                        lastTry = DateTime.UtcNow;
                     }
 
                     if (xivProc != null)

--- a/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/CombatantEx.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/CombatantEx.cs
@@ -124,9 +124,9 @@ namespace FFXIV.Framework.XIVHelper
 
         public bool IsDummy { get; set; } = false;
 
-        public DateTime Timestamp { get; } = DateTime.Now;
+        public DateTime Timestamp { get; } = DateTime.UtcNow;
 
-        public DateTime LastUpdateTimestamp { get; private set; } = DateTime.Now;
+        public DateTime LastUpdateTimestamp { get; private set; } = DateTime.UtcNow;
 
         public ActorItemBase ActorItem { get; set; }
 

--- a/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/CombatantsManager.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/CombatantsManager.cs
@@ -429,7 +429,7 @@ namespace FFXIV.Framework.XIVHelper
 
             lock (LockObject)
             {
-                var now = DateTime.Now;
+                var now = DateTime.UtcNow;
 
                 if ((now - this.lastClearTimestamp).TotalSeconds <= 8.0)
                 {
@@ -453,11 +453,11 @@ namespace FFXIV.Framework.XIVHelper
         }
 
         private static readonly double GarbageThreshold = 10.0d;
-        private DateTime lastGarbageTimestamp = DateTime.Now;
+        private DateTime lastGarbageTimestamp = DateTime.UtcNow;
 
         private void TryGarbage()
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
 
             if ((now - this.lastGarbageTimestamp).TotalSeconds >= GarbageThreshold)
             {

--- a/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/SharlayanHelper.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/SharlayanHelper.cs
@@ -379,7 +379,7 @@ namespace FFXIV.Framework.XIVHelper
                 if (this.CurrentZoneName != currentZoneName)
                 {
                     this.CurrentZoneName = currentZoneName;
-                    this.ZoneChangedTimestamp = DateTime.Now;
+                    this.ZoneChangedTimestamp = DateTime.UtcNow;
 
                     this.IsExistsActors = false;
                     this.ActorList.Clear();
@@ -392,9 +392,9 @@ namespace FFXIV.Framework.XIVHelper
                 if (!this.IsSkipPlayer &&
                     this.IsSkipActor)
                 {
-                    if ((DateTime.Now - this.playerScanTimestamp).TotalMilliseconds > 500)
+                    if ((DateTime.UtcNow - this.playerScanTimestamp).TotalMilliseconds > 500)
                     {
-                        this.playerScanTimestamp = DateTime.Now;
+                        this.playerScanTimestamp = DateTime.UtcNow;
                         this.CurrentPlayer = this._memoryHandler.Reader.GetCurrentPlayer().Entity;
                     }
                 }
@@ -667,7 +667,7 @@ namespace FFXIV.Framework.XIVHelper
                 return;
             }
 
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             if ((now - this.partyListTimestamp).TotalSeconds <= 0.5)
             {
                 return;
@@ -696,7 +696,7 @@ namespace FFXIV.Framework.XIVHelper
                 newPartyList.Except(this.PartyMemberList).Any() ||
                 this.PartyMemberList.Except(newPartyList).Any())
             {
-                this.PartyListChangedTimestamp = DateTime.Now;
+                this.PartyListChangedTimestamp = DateTime.UtcNow;
             }
 
             this.PartyMemberList.Clear();
@@ -764,7 +764,7 @@ namespace FFXIV.Framework.XIVHelper
                 return;
             }
 
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             if ((now - this.lastActionsTimestamp).TotalMilliseconds <= this.ActionsPollingInterval)
             {
                 return;
@@ -935,9 +935,9 @@ namespace FFXIV.Framework.XIVHelper
                 return;
             }
 
-            if ((DateTime.Now - this.lastestGarbageTimestamp) >= TimeSpan.FromMinutes(3))
+            if ((DateTime.UtcNow - this.lastestGarbageTimestamp) >= TimeSpan.FromMinutes(3))
             {
-                this.lastestGarbageTimestamp = DateTime.Now;
+                this.lastestGarbageTimestamp = DateTime.UtcNow;
                 this.GarbageCombatantsDictionary();
             }
         }
@@ -949,7 +949,7 @@ namespace FFXIV.Framework.XIVHelper
                 {
                     var dic = this.CombatantsDictionary;
                     var keys = dic
-                        .Where(x => (DateTime.Now - x.Value.Timestamp) >= TimeSpan.FromMinutes(2.9))
+                        .Where(x => (DateTime.UtcNow - x.Value.Timestamp) >= TimeSpan.FromMinutes(2.9))
                         .Select(x => x.Key)
                         .ToArray();
 
@@ -962,7 +962,7 @@ namespace FFXIV.Framework.XIVHelper
                 {
                     var dic = this.NPCCombatantsDictionary;
                     var keys = dic
-                        .Where(x => (DateTime.Now - x.Value.Timestamp) >= TimeSpan.FromMinutes(2.9))
+                        .Where(x => (DateTime.UtcNow - x.Value.Timestamp) >= TimeSpan.FromMinutes(2.9))
                         .Select(x => x.Key)
                         .ToArray();
 

--- a/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/XIVPluginHelper.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/XIVHelper/XIVPluginHelper.cs
@@ -239,6 +239,10 @@ namespace FFXIV.Framework.XIVHelper
             SharlayanHelper.Instance.IsSkipActor = true;
             SharlayanHelper.Instance.IsSkipParty = true;
 
+            var config = new Sharlayan.SharlayanConfiguration();
+
+            AppLogger.Trace("Sharlayan JSONCacheDirectory = " + config.JSONCacheDirectory.ToString());
+
             var tasksG1 = new System.Action[]
             {
                 () => XIVApi.Instance.Load(),
@@ -480,16 +484,12 @@ namespace FFXIV.Framework.XIVHelper
             var messagetype = logInfo.detectedType;
 
             // 255を超えるメッセージタイプは無視する
-            //if (messagetype > 0xFF)
-            //{
-            //    return;
-            //}
-
-            // メッセージタイプの文字列を除去する
-            if (messagetype <= 0xFF)
+            if (messagetype > 0xFF)
             {
-                line = LogMessageTypeExtensions.RemoveLogMessageType(messagetype, line);
+                return;
             }
+
+            line = LogMessageTypeExtensions.RemoveLogMessageType(messagetype, line);
 
             // メッセージ部分だけを抽出する
             var message = line.Substring(15);
@@ -672,10 +672,10 @@ namespace FFXIV.Framework.XIVHelper
             {
                 this.lineCountTimer.Stop();
 
-                var secounds = this.lineCountTimer.Elapsed.TotalSeconds;
-                if (secounds > 0)
+                var seconds = this.lineCountTimer.Elapsed.TotalSeconds;
+                if (seconds > 0)
                 {
-                    var lps = this.currentLineCount / secounds;
+                    var lps = this.currentLineCount / seconds;
                     if (lps > 0)
                     {
                         if (this.currentLpsIndex > this.lpss.GetUpperBound(0))
@@ -709,7 +709,7 @@ namespace FFXIV.Framework.XIVHelper
         /// </summary>
         private void RefreshActive()
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
 
             if ((now - this.detectedActiveTimestamp).TotalSeconds <= 5.0)
             {
@@ -890,7 +890,7 @@ namespace FFXIV.Framework.XIVHelper
                 return;
             }
 
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             if ((now - this.inCombatTimestamp).TotalSeconds >= 1.0)
             {
                 this.inCombatTimestamp = now;


### PR DESCRIPTION
設定ファイルの読み込み失敗時にバックアップの読み取りにトライする
FFXIV.Framework.configの多重セーブ防止

Hojoringが認識しているカレントディレクトリをログに出力するようにした
OverlayPluginのログを無視するように戻した
Loggerの名前をAppLoggerに統一した
インターバル測定にDateTime.Nowを使っている部分をできるだけDateTime.UtcNowに変更した
TTSのキャッシュファイルが壊れている時にエラーを出力するようにした
