### PR TITLE
bug fix

### DIFF
--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/ConstantKeywords.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/ConstantKeywords.cs
@@ -202,6 +202,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
 
         public static class CommonKeywords
         {
+            public static readonly string SpespeResetOnWipeoutChange = "/spespe reset-on-wipeout"; // reset-on-wipeoutを切り替えるときにタイムラインのリロードが走っては困る
             public static readonly string OverlayPluginMapEffectPrefix = $"] 101:";
 
             public static readonly string CountdownStartPrefix = $"{LogMessageType.ChatLog.ToHex()}:0139::";
@@ -275,6 +276,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
 
         private static readonly IList<AnalyzeKeyword> KeywordsJA = new[]
         {
+            new AnalyzeKeyword() { Keyword = CommonKeywords.SpespeResetOnWipeoutChange, Category = KewordTypes.Record },
             new AnalyzeKeyword() { Keyword = CommonKeywords.OverlayPluginMapEffectPrefix, Category = KewordTypes.Record},
             new AnalyzeKeyword() { Keyword = CommonKeywords.ExAddedCombatant, Category = KewordTypes.Record },
             new AnalyzeKeyword() { Keyword = CommonKeywords.ExPos, Category = KewordTypes.Record },

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/ConstantKeywords.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/ConstantKeywords.cs
@@ -202,7 +202,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
 
         public static class CommonKeywords
         {
-            public static readonly string SpespeResetOnWipeoutChange = "/spespe reset-on-wipeout"; // reset-on-wipeoutを切り替えるときにタイムラインのリロードが走っては困る
+            public static readonly string SpespeResetOnWipeoutChange = "/spespe reset-on-wipe-out"; // reset-on-wipeoutを切り替えるときにタイムラインのリロードが走っては困る
             public static readonly string OverlayPluginMapEffectPrefix = $"] 101:";
 
             public static readonly string CountdownStartPrefix = $"{LogMessageType.ChatLog.ToHex()}:0139::";

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TextCommandController.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TextCommandController.cs
@@ -56,7 +56,7 @@ namespace ACT.SpecialSpellTimer
         /// </summary>
         private static readonly (string keyword, Action<bool> change)[] optionCommands = new[]
         {
-            ("reset-on-wipeout", new Action<bool>((value) => Settings.Default.ResetOnWipeOut = value))
+            ("reset-on-wipe-out", new Action<bool>((value) => Settings.Default.ResetOnWipeOut = value))
         };
 
         /// <summary>

--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TextCommandController.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/TextCommandController.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using ACT.SpecialSpellTimer.Config;
 using ACT.SpecialSpellTimer.Models;
 using ACT.SpecialSpellTimer.Sound;
+using ACT.SpecialSpellTimer.Utility;
 using FFXIV.Framework.XIVHelper;
 
 namespace ACT.SpecialSpellTimer
@@ -380,6 +381,8 @@ namespace ACT.SpecialSpellTimer
                 "on" => true,
                 _ => false,
             };
+
+            Logger.Write("[TL] " + option + " " + value.ToString());
 
             optionCommands.FirstOrDefault(x => x.keyword == command).change?.Invoke(value);
 

--- a/source/ACT.XIVLog/VideoCapture.cs
+++ b/source/ACT.XIVLog/VideoCapture.cs
@@ -151,12 +151,12 @@ namespace ACT.XIVLog
             }
 
             // 録画を止めないようにする
-            if (xivlog.Log.Contains("reset-on-wipeout disabled"))
+            if (xivlog.Log.Contains("reset-on-wipe-out disabled"))
             {
                 ignoreWipeout = true;
             }
             // 元に戻す
-            if (xivlog.Log.Contains("reset-on-wipeout enabled"))
+            if (xivlog.Log.Contains("reset-on-wipe-out enabled"))
             {
                 ignoreWipeout = false;
             }


### PR DESCRIPTION
ログをContainsIgnoreCaseでキーワード検索してStartまたはEndを探している部分で
reset-on-wipeoutのwipeoutを
        public static readonly string Wipeout = "WIPEOUT";
        public static readonly string WipeoutLog = $"{Wipeout}";
で引っかけてしまい絶バハの転生の炎のときに
/spespe reset-on-wipeout disabled
/spespe reset-on-wipeout enabled
を発行するとタイムラインが初期化されてしまう問題に対策した