### PR TITLE
bug fix

### DIFF
--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/Ticker.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/Models/Ticker.cs
@@ -686,7 +686,7 @@ namespace ACT.SpecialSpellTimer.Models
 
         public void SimulateMatch()
         {
-            var now = DateTime.UtcNow;
+            var now = DateTime.Now;
 
             // 擬似的にマッチ状態にする
             this.IsTest = true;


### PR DESCRIPTION
#408 スペル/テロップの「擬似的にマッチさせる」の遅延通知タイマーのエンバグを修正