### PR TITLE
minor fix

### DIFF
--- a/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/ConstantKeywords.cs
+++ b/source/ACT.SpecialSpellTimer/ACT.SpecialSpellTimer.Core/RaidTimeline/ConstantKeywords.cs
@@ -224,6 +224,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
             public static readonly string AnalyzeTimeStart = "/analyze start";
             public static readonly string AnalyzeTimeEnd = "/analyze end";
             public static readonly string ChangedZone = $"] {LogMessageType.Territory.ToHex()}:";
+            public static readonly string NetworkStatusEffect26 = $"] {LogMessageType.StatusList.ToHex()}:";
 
             public static readonly string AddedRegexPattern
                 = $@"\[EX\] \+Combatant name=(?<actor>.+) X=";
@@ -320,6 +321,7 @@ namespace ACT.SpecialSpellTimer.RaidTimeline
             new AnalyzeKeyword() { Keyword = "レディチェックを開始しました。", Category = KewordTypes.End },
             new AnalyzeKeyword() { Keyword = "「", Category = KewordTypes.Action },
             new AnalyzeKeyword() { Keyword = "」", Category = KewordTypes.Action },
+            new AnalyzeKeyword() { Keyword = CommonKeywords.NetworkStatusEffect26, Category = KewordTypes.Record },
         };
 
         private static readonly Dictionary<string, Regex> AnalyzeRegexesJA = new Dictionary<string, Regex>()

--- a/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/PluginCore.cs
+++ b/source/ACT.TTSYukkuri/ACT.TTSYukkuri.Core/PluginCore.cs
@@ -621,6 +621,36 @@ namespace ACT.TTSYukkuri
             {
                 IsSilent = true,
             });
+
+            // ミュートを解除されたときにサウンドデバイスを初期化する
+            TextCommandBridge.Instance.Subscribe(new TextCommand(
+            (string logLine, out Match match) =>
+            {
+                var result = false;
+                match = null;
+
+                if (!string.IsNullOrEmpty(logLine))
+                {
+                    if (logLine.Contains(UnMuteKeywords.UnMuteJP) ||
+                    logLine.Contains(UnMuteKeywords.UnMuteEN) ||
+                    logLine.Contains(UnMuteKeywords.UnMuteDE) ||
+                    logLine.Contains(UnMuteKeywords.UnMuteFR)
+                    )
+                    {
+                        result = true;
+                    }
+                }
+
+                return result;
+            },
+            (string logLine, Match match) =>
+            {
+                SoundPlayerWrapper.Init();
+                this.AppLogger.Info("Playback stream initialized.");
+            })
+            {
+                IsSilent = true,
+            });
         }
 
         /// <summary>

--- a/source/FFXIV.Framework/FFXIV.Framework/Common/UnMuteKeywords.cs
+++ b/source/FFXIV.Framework/FFXIV.Framework/Common/UnMuteKeywords.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFXIV.Framework.Common
+{
+    public static class UnMuteKeywords
+    {
+        public static readonly string UnMuteJP = "ミュートを解除しました。";
+        public static readonly string UnMuteEN = "Master volume unmuted.";
+        public static readonly string UnMuteDE = "Hauptlautstärke wieder eingeschaltet";
+        public static readonly string UnMuteFR = "Vous avez activé le volume général.";
+    }
+}

--- a/source/FFXIV.Framework/FFXIV.Framework/FFXIV.Framework.csproj
+++ b/source/FFXIV.Framework/FFXIV.Framework/FFXIV.Framework.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Common\KeyValue.cs" />
     <Compile Include="Common\MasterFilePublisher.cs" />
     <Compile Include="Common\CommonSounds.cs" />
+    <Compile Include="Common\UnMuteKeywords.cs" />
     <Compile Include="Common\WipeoutKeywords.cs" />
     <Compile Include="Common\WrappingStream.cs" />
     <Compile Include="Common\XAudioPlayer.cs" />


### PR DESCRIPTION
Autologに0x26が出力されるようにした
マスターボリュームのミュートを解除したときにSoundPlayerWrapper.Initを呼ぶようにした
([769057](https://github.com/anoyetta/ACT.Hojoring/commit/76905748d998406f411cd9d3e64a7ec5236e52e8)で元に戻した機能のリベンジ)